### PR TITLE
882: Replace pipenv lock -r with pipenv requirements

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -56,7 +56,7 @@ jobs:
         export ALLOWED_HOSTS='localhost 127.0.0.1 0.0.0.0'
         export SECRET_KEY=1234
         export DEBUG=TRUE
-        pipenv lock -r > requirements.txt
+        pipenv requirements > requirements.txt
         make int_test
       env:
         AWS_ACCESS_KEY_ID_S3_STORE: ${{ secrets.AWS_ACCESS_KEY_ID_S3_STORE }}

--- a/.github/workflows/deploy-to-test.yml
+++ b/.github/workflows/deploy-to-test.yml
@@ -58,7 +58,7 @@ jobs:
         export SECRET_KEY=1234
         export DEBUG=TRUE
         export INTEGRATION_TEST=FALSE
-        pipenv lock -r > requirements.txt
+        pipenv requirements > requirements.txt
         make int_test
       env:
         AWS_ACCESS_KEY_ID_S3_STORE: ${{ secrets.AWS_ACCESS_KEY_ID_S3_STORE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         export SECRET_KEY=1234
         export DEBUG=TRUE
         export INTEGRATION_TEST=FALSE
-        pipenv lock -r > requirements.txt
+        pipenv requirements > requirements.txt
         make int_test
       env:
         AWS_ACCESS_KEY_ID_S3_STORE: ${{ secrets.AWS_ACCESS_KEY_ID_S3_STORE }}

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ test:
 	npm test
 
 int_test:
-	pipenv lock -r > requirements.txt
+	pipenv requirements > requirements.txt
 	python3 stack_tests/main.py
 
 deploy_prototype:

--- a/deploy_feature_to_paas/app/build_env.py
+++ b/deploy_feature_to_paas/app/build_env.py
@@ -115,7 +115,7 @@ class BuildEnv:
     def create_requirements(self) -> bool:
         """Creates requirements.txt and ensures it has content"""
         while True:
-            os.system("pipenv lock -r > requirements.txt")
+            os.system("pipenv requirements > requirements.txt")
             with open("requirements.txt", "r", encoding="utf-8") as file:
                 data: str = file.read().replace("\n", "")
                 if len(data) > 0:

--- a/stack_tests/django_app.Dockerfile
+++ b/stack_tests/django_app.Dockerfile
@@ -23,7 +23,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install pipenv
 RUN pipenv install -d
 RUN pipenv install
-RUN pipenv lock -r > requirements.txt
+RUN pipenv requirements > requirements.txt
 RUN pip3 install -r requirements.txt
 RUN npm i
 COPY report_viewer/ /code/report_viewer/

--- a/stack_tests/report_viewer_app.Dockerfile
+++ b/stack_tests/report_viewer_app.Dockerfile
@@ -23,7 +23,7 @@ RUN pip3 install --upgrade pip
 RUN pip3 install pipenv
 RUN pipenv install -d
 RUN pipenv install
-RUN pipenv lock -r > requirements.txt
+RUN pipenv requirements > requirements.txt
 RUN pip3 install -r requirements.txt
 RUN npm i
 COPY report_viewer/ /code/report_viewer/


### PR DESCRIPTION
Trello card [#882](https://trello.com/c/kAJl5GKu/882-fix-devops-scripts-following-changes-to-pipenv).