### PR TITLE
889: Map .gov.uk domains from platform to viewer

### DIFF
--- a/accessibility_monitoring_platform/apps/reports/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/reports/tests/test_utils.py
@@ -392,7 +392,15 @@ def test_move_table_row_down(rf):
             "https://reports.accessibility-monitoring.service.gov.uk",
         ),
         (
+            "https://platform.accessibility-monitoring.gov.uk",
+            "https://reports.accessibility-monitoring.service.gov.uk",
+        ),
+        (
             "https://accessibility-monitoring-platform-test.com",
+            "https://reports-test.accessibility-monitoring.service.gov.uk",
+        ),
+        (
+            "https://platform-test.accessibility-monitoring.gov.uk",
             "https://reports-test.accessibility-monitoring.service.gov.uk",
         ),
         ("https://512-local-branch.com", "http://512-local-branch-report-viewer.com"),

--- a/accessibility_monitoring_platform/apps/reports/utils.py
+++ b/accessibility_monitoring_platform/apps/reports/utils.py
@@ -260,7 +260,11 @@ def get_report_viewer_url_prefix(request: HttpRequest) -> str:
             return "http://localhost:8002"
         elif "accessibility-monitoring-platform-production" in domain_name:
             return "https://reports.accessibility-monitoring.service.gov.uk"
+        elif "platform.accessibility-monitoring" in domain_name:
+            return "https://reports.accessibility-monitoring.service.gov.uk"
         elif "accessibility-monitoring-platform-test" in domain_name:
+            return "https://reports-test.accessibility-monitoring.service.gov.uk"
+        elif "platform-test.accessibility-monitoring" in domain_name:
             return "https://reports-test.accessibility-monitoring.service.gov.uk"
         else:
             domain_name_split = domain_name.split(".")


### PR DESCRIPTION
Trello card [#889](https://trello.com/c/30NMisfr/889-add-govuk-domains-to-links-to-published-reports).