### PR TITLE
889: Use working cloudfoundry python-buildpack version 1.7.58

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Push to cf
       run: |
         cf login -a ${{ secrets.CF_ENDPOINT }} -u ${{ secrets.CF_USER }} -p '${{ secrets.CF_PASSWORD }}' -o ${{ secrets.CF_ORGANISATION }} -s monitoring-platform-production
-        cf push -f cf_manifest/manifest-prod.yml
+        cf push -f cf_manifest/manifest-prod.yml -b https://github.com/cloudfoundry/python-buildpack#develop
 
     - name: Smoke tests
       run: |

--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Push to cf
       run: |
         cf login -a ${{ secrets.CF_ENDPOINT }} -u ${{ secrets.CF_USER }} -p '${{ secrets.CF_PASSWORD }}' -o ${{ secrets.CF_ORGANISATION }} -s monitoring-platform-production
-        cf push -f cf_manifest/manifest-prod.yml -b https://github.com/cloudfoundry/python-buildpack#develop
+        cf push -f cf_manifest/manifest-prod.yml -b https://github.com/cloudfoundry/python-buildpack#v1.7.58
 
     - name: Smoke tests
       run: |

--- a/.github/workflows/deploy-to-test.yml
+++ b/.github/workflows/deploy-to-test.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Push to cf
       run: |
         cf login -a ${{ secrets.CF_ENDPOINT }} -u ${{ secrets.CF_USER }} -p '${{ secrets.CF_PASSWORD }}' -o ${{ secrets.CF_ORGANISATION }} -s monitoring-platform-test
-        cf push -f cf_manifest/manifest-test.yml
+        cf push -f cf_manifest/manifest-test.yml -b https://github.com/cloudfoundry/python-buildpack#develop
 
     - name: Smoke tests
       run: |

--- a/.github/workflows/deploy-to-test.yml
+++ b/.github/workflows/deploy-to-test.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Push to cf
       run: |
         cf login -a ${{ secrets.CF_ENDPOINT }} -u ${{ secrets.CF_USER }} -p '${{ secrets.CF_PASSWORD }}' -o ${{ secrets.CF_ORGANISATION }} -s monitoring-platform-test
-        cf push -f cf_manifest/manifest-test.yml -b https://github.com/cloudfoundry/python-buildpack#develop
+        cf push -f cf_manifest/manifest-test.yml -b https://github.com/cloudfoundry/python-buildpack#v1.7.58
 
     - name: Smoke tests
       run: |

--- a/deploy_feature_to_paas/app/build_env.py
+++ b/deploy_feature_to_paas/app/build_env.py
@@ -199,7 +199,7 @@ class BuildEnv:
         self.create_manifest()  # Creates manifest before deloying Django app
         print(">>> pushing app to PaaS")
         subprocess.run(
-            f"cf push -f {self.manifest_path}".split(),
+            f"cf push -f {self.manifest_path} -b https://github.com/cloudfoundry/python-buildpack#v1.7.58".split(),
             stderr=sys.stderr,
             stdout=sys.stdout,
             check=True,


### PR DESCRIPTION
Trello card [#899](https://trello.com/c/MAD3dWKZ/899-unable-to-deploy-broken-buildpack).