### PR TITLE
889: Pin fixed python-buildpack version 1.7.58 in manifests

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -121,7 +121,7 @@ jobs:
     - name: Push to cf
       run: |
         cf login -a ${{ secrets.CF_ENDPOINT }} -u ${{ secrets.CF_USER }} -p '${{ secrets.CF_PASSWORD }}' -o ${{ secrets.CF_ORGANISATION }} -s monitoring-platform-production
-        cf push -f cf_manifest/manifest-prod.yml -b https://github.com/cloudfoundry/python-buildpack#v1.7.58
+        cf push -f cf_manifest/manifest-prod.yml
 
     - name: Smoke tests
       run: |

--- a/.github/workflows/deploy-to-test.yml
+++ b/.github/workflows/deploy-to-test.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Push to cf
       run: |
         cf login -a ${{ secrets.CF_ENDPOINT }} -u ${{ secrets.CF_USER }} -p '${{ secrets.CF_PASSWORD }}' -o ${{ secrets.CF_ORGANISATION }} -s monitoring-platform-test
-        cf push -f cf_manifest/manifest-test.yml -b https://github.com/cloudfoundry/python-buildpack#v1.7.58
+        cf push -f cf_manifest/manifest-test.yml
 
     - name: Smoke tests
       run: |

--- a/cf_manifest/manifest-prod.yml
+++ b/cf_manifest/manifest-prod.yml
@@ -3,7 +3,7 @@ applications:
 - name: accessibility-monitoring-platform-production
   instances: 1
   buildpacks:
-    - python_buildpack
+    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
   services:
     - monitoring-platform-default-db
     - s3-report-store
@@ -19,7 +19,7 @@ applications:
 - name: accessibility-monitoring-report-viewer-production
   instances: 1
   buildpacks:
-    - python_buildpack
+    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
   services:
     - monitoring-platform-default-db
     - s3-report-store

--- a/cf_manifest/manifest-test.yml
+++ b/cf_manifest/manifest-test.yml
@@ -3,7 +3,7 @@ applications:
 - name: accessibility-monitoring-platform-test
   instances: 1
   buildpacks:
-    - python_buildpack
+    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
   services:
     - monitoring-platform-default-db
     - s3-report-store
@@ -19,7 +19,7 @@ applications:
 - name: accessibility-monitoring-report-viewer-test
   instances: 1
   buildpacks:
-    - python_buildpack
+    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
   services:
     - monitoring-platform-default-db
     - s3-report-store

--- a/deploy_feature_to_paas/app/build_env.py
+++ b/deploy_feature_to_paas/app/build_env.py
@@ -199,7 +199,7 @@ class BuildEnv:
         self.create_manifest()  # Creates manifest before deloying Django app
         print(">>> pushing app to PaaS")
         subprocess.run(
-            f"cf push -f {self.manifest_path} -b https://github.com/cloudfoundry/python-buildpack#v1.7.58".split(),
+            f"cf push -f {self.manifest_path}".split(),
             stderr=sys.stderr,
             stdout=sys.stdout,
             check=True,

--- a/deploy_feature_to_paas/main.py
+++ b/deploy_feature_to_paas/main.py
@@ -54,6 +54,7 @@ def main() -> bool:
     config_processed: SettingsType = reconfigure_config_file(config)
     template_object = {
         "app_name": config_processed["app_name"],
+        "buildpack": "https://github.com/cloudfoundry/python-buildpack#v1.7.58",
         "report_viewer_app_name": config_processed["report_viewer_app_name"],
         "secret_key": get_random_secret_key(),
         "db": config_processed["db_name"],

--- a/deploy_feature_to_paas/main.py
+++ b/deploy_feature_to_paas/main.py
@@ -54,7 +54,6 @@ def main() -> bool:
     config_processed: SettingsType = reconfigure_config_file(config)
     template_object = {
         "app_name": config_processed["app_name"],
-        "buildpack": "https://github.com/cloudfoundry/python-buildpack#v1.7.58",
         "report_viewer_app_name": config_processed["report_viewer_app_name"],
         "secret_key": get_random_secret_key(),
         "db": config_processed["db_name"],

--- a/deploy_feature_to_paas/manifest_template.txt
+++ b/deploy_feature_to_paas/manifest_template.txt
@@ -3,7 +3,7 @@ applications:
 - name: $app_name
   instances: 1
   buildpacks:
-    - python_buildpack
+    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
   services:
     - $db
     - $s3_report_store
@@ -20,7 +20,7 @@ applications:
 - name: $report_viewer_app_name
   instances: 1
   buildpacks:
-    - python_buildpack
+    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
   services:
     - $db
     - $s3_report_store


### PR DESCRIPTION
Trello card [#899](https://trello.com/c/MAD3dWKZ/899-unable-to-deploy-broken-buildpack).