### PR TITLE
902: Stop pinning python_buildpack to specific version

### DIFF
--- a/cf_manifest/manifest-prod.yml
+++ b/cf_manifest/manifest-prod.yml
@@ -3,7 +3,7 @@ applications:
 - name: accessibility-monitoring-platform-production
   instances: 1
   buildpacks:
-    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
+    - python_buildpack
   services:
     - monitoring-platform-default-db
     - s3-report-store
@@ -19,7 +19,7 @@ applications:
 - name: accessibility-monitoring-report-viewer-production
   instances: 1
   buildpacks:
-    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
+    - python_buildpack
   services:
     - monitoring-platform-default-db
     - s3-report-store

--- a/cf_manifest/manifest-test.yml
+++ b/cf_manifest/manifest-test.yml
@@ -3,7 +3,7 @@ applications:
 - name: accessibility-monitoring-platform-test
   instances: 1
   buildpacks:
-    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
+    - python_buildpack
   services:
     - monitoring-platform-default-db
     - s3-report-store
@@ -19,7 +19,7 @@ applications:
 - name: accessibility-monitoring-report-viewer-test
   instances: 1
   buildpacks:
-    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
+    - python_buildpack
   services:
     - monitoring-platform-default-db
     - s3-report-store

--- a/deploy_feature_to_paas/manifest_template.txt
+++ b/deploy_feature_to_paas/manifest_template.txt
@@ -3,7 +3,7 @@ applications:
 - name: $app_name
   instances: 1
   buildpacks:
-    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
+    - python_buildpack
   services:
     - $db
     - $s3_report_store
@@ -20,7 +20,7 @@ applications:
 - name: $report_viewer_app_name
   instances: 1
   buildpacks:
-    - https://github.com/cloudfoundry/python-buildpack#v1.7.58
+    - python_buildpack
   services:
     - $db
     - $s3_report_store


### PR DESCRIPTION
Trello card [#902](https://trello.com/c/eeA0tYIc/902-revert-pythonbuildpack-version-pinning)