### PR TITLE
907: Add pytest to normal requirements - for smoke tests

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,3 +15,4 @@ django-axes>=5.33.0
 django-two-factor-auth
 phonenumbers
 django-csp
+pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ async-generator==1.10
 attrs==22.1.0
     # via
     #   outcome
+    #   pytest
     #   trio
 boto3==1.24.65
     # via
@@ -69,6 +70,8 @@ idna==3.3
     #   trio
 importlib-metadata==4.12.0
     # via markdown
+iniconfig==1.1.1
+    # via pytest
 jinja2==3.1.2
     # via moto
 jmespath==1.0.1
@@ -87,16 +90,28 @@ notifications-python-client==6.3.0
     # via -r requirements.in
 outcome==1.2.0
     # via trio
+packaging==21.3
+    # via pytest
 phonenumbers==8.12.54
     # via -r requirements.in
+pluggy==1.0.0
+    # via pytest
 psycopg2==2.9.3
     # via -r requirements.in
+py==1.11.0
+    # via pytest
 pycparser==2.21
     # via cffi
 pyjwt==2.4.0
     # via notifications-python-client
+pyparsing==3.0.9
+    # via packaging
 pysocks==1.7.1
     # via urllib3
+pytest==7.1.3
+    # via pytest-django
+pytest-django==4.5.2
+    # via -r requirements.in
 python-dateutil==2.8.2
     # via
     #   botocore
@@ -129,6 +144,8 @@ sortedcontainers==2.4.0
     # via trio
 sqlparse==0.4.2
     # via django
+tomli==2.0.1
+    # via pytest
 tqdm==4.64.0
     # via webdriver-manager
 trio==0.21.0

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -2,5 +2,4 @@
 flake8
 pylint
 coverage
-pytest-django
 black


### PR DESCRIPTION
Trello card [#907](https://trello.com/c/wOC8Mwp7/907-stop-using-pipenv).