### PR TITLE
914: Upgrade Django to version 4.1.1.

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django>=4.1
+django
 python-dotenv
 psycopg2
 notifications-python-client
@@ -11,7 +11,7 @@ xmltodict
 Markdown
 moto
 webdriver-manager
-django-axes>=5.33.0
+django-axes
 django-two-factor-auth
 phonenumbers
 django-csp

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ cryptography==37.0.4
     # via moto
 dj-database-url==1.0.0
     # via -r requirements.in
-django==4.1
+django==4.1.1
     # via
     #   -r requirements.in
     #   dj-database-url


### PR DESCRIPTION
Trello card [#914](https://trello.com/c/jnziVory/914-upgrade-django-to-411).