### PR TITLE
928: Make report header full width.

### DIFF
--- a/common/templates/reports_common/accessibility_report_container.html
+++ b/common/templates/reports_common/accessibility_report_container.html
@@ -27,7 +27,7 @@
             </div>
         {% else %}
             <div class="govuk-grid-row border-bottom-report">
-                <div class="govuk-grid-column-two-thirds">
+                <div class="govuk-grid-column-full">
                     <div class="govuk-!-margin-top-8 govuk-!-margin-bottom-8">
                         <h1 class="govuk-heading-xl">{{ report.wrapper.title }}</h1>
                     </div>


### PR DESCRIPTION
Trello card [#928](https://trello.com/c/uQoUPdrs/928-go-full-width-for-the-report-title).