### PR TITLE
927: Reenable issue report link in test platform.

### DIFF
--- a/accessibility_monitoring_platform/apps/common/templates/common/phase_banner.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/phase_banner.html
@@ -3,7 +3,7 @@
         <strong class="govuk-tag govuk-phase-banner__content__tag">alpha</strong>
         <span class="govuk-phase-banner__text">
             This is a new service – Please
-            {% if django_settings.AMP_PROTOTYPE_NAME %}
+            {% if django_settings.AMP_PROTOTYPE_NAME and django_settings.AMP_PROTOTYPE_NAME != 'TEST' %}
                 report
             {% else %}
                 <a href="{% url 'common:issue-report' %}?page_url={{ request.path }}"


### PR DESCRIPTION
Trello card [#927](https://trello.com/c/7u7ljW3S/927-report-issue-disabled-on-test).