### PR TITLE
917: Name nav tags in report unique to screen readers.

### DIFF
--- a/common/templates/reports_common/accessibility_report_container.html
+++ b/common/templates/reports_common/accessibility_report_container.html
@@ -60,7 +60,7 @@
                     <div class="related-content-wrapper">
                         <h2 class="govuk-heading-m" id="related-content">Related content</h2>
                     </div>
-                    <nav>
+                    <nav aria-label="Related content">
                         {{ report.wrapper.related_content|markdown_to_html }}
                     </nav>
                 </div>

--- a/common/templates/reports_common/accessibility_report_v1_0_0__20220406.html
+++ b/common/templates/reports_common/accessibility_report_v1_0_0__20220406.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 <div class="amp-no-bullet-points">
-    <nav>
+    <nav aria-label="Table of contents">
         <h2 id="contents">Contents</h2>
         <ul>
             {% for section in report.top_level_sections %}


### PR DESCRIPTION
Trello card [#917](https://trello.com/c/3rMoPlV8/917-add-role-to-nav-bar-element-in-report-viewer).