### PR TITLE
921: Treat notes fields' content as markdown.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/summary.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/summary.html
@@ -68,7 +68,7 @@
                                             {% for failure in failures %}
                                                 <tr class="govuk-table__row ">
                                                     <th scope="row" class="govuk-table__header amp-width-one-half">{{ failure.wcag_definition.name }}</th>
-                                                    <td class="govuk-table__cell amp-width-one-half amp-notes">{{ failure.notes }}</td>
+                                                    <td class="govuk-table__cell amp-width-one-half amp-notes">{{ failure.notes|markdown_to_html }}</td>
                                                 </tr>
                                             {% endfor %}
                                         </tbody>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/reminders.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/reminders.html
@@ -26,7 +26,7 @@
             </tr>
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell amp-width-one-half">{{ case.reminder.due_date|amp_date }}</td>
-                <td class="govuk-table__cell amp-width-one-half"><p class="govuk-body-m cases-notes">{{ case.reminder.description }}</p></td>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ case.reminder.description|markdown_to_html }}</td>
             </tr>
         </tbody>
     </table>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_correspondence.html
@@ -52,9 +52,7 @@
         </tr>
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">Correspondence notes</th>
-            <td class="govuk-table__cell">
-                {% if case.correspondence_notes %}<p class="govuk-body-m cases-notes">{{ case.correspondence_notes }}</p>{% endif %}
-            </td>
+            <td class="govuk-table__cell amp-notes">{{ case.correspondence_notes|markdown_to_html }}</td>
 
         </tr>
     </tbody>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/twelve_week_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/twelve_week_correspondence.html
@@ -40,9 +40,7 @@
         </tr>
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header">12-week correspondence notes</th>
-            <td class="govuk-table__cell">
-                {% if case.twelve_week_correspondence_notes %}<p class="govuk-body-m cases-notes">{{ case.twelve_week_correspondence_notes }}</p>{% endif %}
-            </td>
+            <td class="govuk-table__cell amp-notes">{{ case.twelve_week_correspondence_notes|markdown_to_html }}</td>
         </tr>
     </tbody>
 </table>

--- a/accessibility_monitoring_platform/apps/comments/templates/comment_row.html
+++ b/accessibility_monitoring_platform/apps/comments/templates/comment_row.html
@@ -3,9 +3,9 @@
     <b class="govuk-body-l govuk-!-font-weight-bold">{{ item.user.first_name }} {{ item.user.last_name }} </b>
     on {{ item.created_date|amp_datetime }}
 </p>
-<p class="govuk-body">
-    {{ item.body }}
-</p>
+<div class="govuk-body">
+    {{ item.body|markdown_to_html }}
+</div>
 {% if request.user == item.user  %}
     <form method="post" action="{% url 'comments:remove-comment' item.id %}">
         {% csrf_token %}

--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -303,10 +303,6 @@ img, .amp-max-width-100 {
     font-size: x-large;
     color: #2F80ED;
 }
-.cases-notes {
-    margin: 0;
-    white-space: pre-line;
-}
 .cases-margin-top {
     margin-top: 20px;
 }


### PR DESCRIPTION
Trello card [#921](https://trello.com/c/o5Ej0ZMO/921-run-note-fields-through-markdown).