### PR TITLE
874: Change correspondence overdue period from 5 days to 7.

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/models.py
+++ b/accessibility_monitoring_platform/apps/cases/models.py
@@ -764,7 +764,7 @@ class Case(VersionModel):
     @property
     def in_report_correspondence_progress(self) -> str:
         now = date.today()
-        five_days_ago = now - timedelta(days=5)
+        seven_days_ago = now - timedelta(days=7)
         if (
             self.report_followup_week_1_due_date
             and self.report_followup_week_1_due_date > now
@@ -791,16 +791,16 @@ class Case(VersionModel):
             and self.report_followup_week_4_sent_date is None
         ):
             return "4-week followup due"
-        elif self.report_followup_week_4_sent_date > five_days_ago:
+        elif self.report_followup_week_4_sent_date > seven_days_ago:
             return "4-week followup sent, waiting five days for response"
-        elif self.report_followup_week_4_sent_date <= five_days_ago:
+        elif self.report_followup_week_4_sent_date <= seven_days_ago:
             return "4-week followup sent, case needs to progress"
         return "Unknown"
 
     @property
     def twelve_week_correspondence_progress(self) -> str:
         now = date.today()
-        five_days_ago = now - timedelta(days=5)
+        seven_days_ago = now - timedelta(days=5)
         if (
             self.twelve_week_1_week_chaser_due_date
             and self.twelve_week_1_week_chaser_due_date > now
@@ -813,9 +813,9 @@ class Case(VersionModel):
             and self.twelve_week_1_week_chaser_sent_date is None
         ):
             return "1-week followup due"
-        elif self.twelve_week_1_week_chaser_sent_date > five_days_ago:
+        elif self.twelve_week_1_week_chaser_sent_date > seven_days_ago:
             return "1-week followup sent, waiting five days for response"
-        elif self.twelve_week_1_week_chaser_sent_date <= five_days_ago:
+        elif self.twelve_week_1_week_chaser_sent_date <= seven_days_ago:
             return "1-week followup sent, case needs to progress"
         return "Unknown"
 

--- a/accessibility_monitoring_platform/apps/overdue/tests.py
+++ b/accessibility_monitoring_platform/apps/overdue/tests.py
@@ -188,7 +188,10 @@ def test_in_probation_period_overdue():
 
 @pytest.mark.django_db
 def test_in_12_week_correspondence_1_week_followup_overdue():
-    """Creates two cases; one that is not overdue and another that needs a one-week follow-up after the 12-week waiting period."""
+    """
+    Creates two cases; one that is not overdue and another that needs
+    a one-week follow-up after the 12-week waiting period.
+    """
     user: User = User.objects.create()
     create_case(user)
 
@@ -209,7 +212,10 @@ def test_in_12_week_correspondence_1_week_followup_overdue():
 
 @pytest.mark.django_db
 def test_in_12_week_correspondence_psb_overdue_after_one_week_reminder():
-    """Creates two cases; one that is not overdue and another that needs to move to final decision after the 12-week waiting period."""
+    """
+    Creates two cases; one that is not overdue and another that needs
+    to move to final decision after the 12-week waiting period.
+    """
     user: User = User.objects.create()
     create_case(user)
 


### PR DESCRIPTION
Trello card [#874](https://trello.com/c/IhTM41a6/874-report-correspondence-has-five-working-days-in-the-chaser-currently-it-is-five-cal-days).