### PR TITLE
932: Link to report publisher from case search results.

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/case_list.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/case_list.html
@@ -137,7 +137,7 @@
                                                 {% endif %}
                                                 {% if case.report_methodology == 'platform' and case.report %}
                                                     <a
-                                                        href="{% url 'reports:report-detail' case.report.id %}"
+                                                        href="{% url 'reports:report-publisher' case.report.id %}"
                                                         class="govuk-link govuk-link--no-visited-state amp-margin-bottom-0"
                                                     >
                                                         View report


### PR DESCRIPTION
Trello card [#932](https://trello.com/c/MULp9Vx8/932-change-view-report-link-in-search-results-to-redirect-to-the-report-publisher-page-and-not-the-edit-report-page).