### PR TITLE
939: Correct breadcrumbs in report UI.

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
@@ -74,7 +74,7 @@
                                         {% else %}
                                             HTML report has not been published. Publish report in
                                             <a
-                                                href="{% url 'reports:report-detail' case.report.id %}"
+                                                href="{% url 'reports:edit-report' case.report.id %}"
                                                 class="govuk-link govuk-link--no-visited-state"
                                             >
                                                 case > report

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
@@ -48,7 +48,7 @@
                         A published report does not exist for this case. Create a report in
                         {% if case.report %}
                             <a
-                                href="{% url 'reports:report-detail' case.report.id %}"
+                                href="{% url 'reports:edit-report' case.report.id %}"
                                 class="govuk-link govuk-link--no-visited-state"
                             >
                                 case > report

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -2256,7 +2256,7 @@ def test_platform_report_correspondence_shows_link_to_report_if_none_published(
     """
     case: Case = Case.objects.create()
     report: Report = Report.objects.create(case=case)
-    report_detail_url: str = reverse("reports:report-detail", kwargs={"pk": report.id})  # type: ignore
+    report_detail_url: str = reverse("reports:edit-report", kwargs={"pk": report.id})  # type: ignore
 
     response: HttpResponse = admin_client.get(
         reverse("cases:edit-report-correspondence", kwargs={"pk": case.id}),  # type: ignore
@@ -2403,7 +2403,7 @@ def test_platform_qa_process_shows_link_to_publish_report(admin_client):
     case: Case = Case.objects.create()
 
     report: Report = Report.objects.create(case=case)
-    report_url: str = reverse("reports:report-detail", kwargs={"pk": report.id})  # type: ignore
+    report_url: str = reverse("reports:edit-report", kwargs={"pk": report.id})  # type: ignore
 
     response: HttpResponse = admin_client.get(
         reverse("cases:edit-qa-process", kwargs={"pk": case.id}),  # type: ignore

--- a/accessibility_monitoring_platform/apps/reports/models.py
+++ b/accessibility_monitoring_platform/apps/reports/models.py
@@ -95,7 +95,7 @@ class Report(VersionModel):
         super().save(*args, **kwargs)
 
     def get_absolute_url(self) -> str:
-        return reverse("reports:report-detail", kwargs={"pk": self.pk})
+        return reverse("reports:edit-report", kwargs={"pk": self.pk})
 
     @property
     def template_path(self) -> str:

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/forms/metadata.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/forms/metadata.html
@@ -15,7 +15,10 @@
                 <a class="govuk-breadcrumbs__link" href="{% url 'cases:case-detail' report.case.id %}">Case</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-detail' report.id %}">Report</a>
+                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-publisher' report.id %}">Report publisher</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link" href="{% url 'reports:edit-report' report.id %}">Edit report</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
                 Report metadata
@@ -68,10 +71,10 @@
                                 data-module="govuk-button"
                             />
                             <a
-                                href="{% url 'reports:report-detail' report.id %}"
+                                href="{% url 'reports:edit-report' report.id %}"
                                 class="govuk-link govuk-link--no-visited-state"
                             >
-                                Cancel and return to report view
+                                Cancel and return to edit report
                             </a>
                         </div>
                     </div>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/forms/section.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/forms/section.html
@@ -17,7 +17,10 @@
                 <a class="govuk-breadcrumbs__link" href="{% url 'cases:case-detail' section.report.case.id %}">Case</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-detail' section.report.id %}">Report</a>
+                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-publisher' section.report.id %}">Report publisher</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link" href="{% url 'reports:edit-report' section.report.id %}">Edit report</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
                 {{ section.name }}
@@ -86,10 +89,10 @@
                                 data-module="govuk-button"
                             />
                             <a
-                                href="{% url 'reports:report-detail' section.report.id %}"
+                                href="{% url 'reports:edit-report' section.report.id %}"
                                 class="govuk-link govuk-link--no-visited-state"
                             >
-                                Cancel and return to report view
+                                Cancel and return to edit report
                             </a>
                         </div>
                     </div>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/report_edit.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/report_edit.html
@@ -13,7 +13,7 @@
                 <a class="govuk-breadcrumbs__link" href="{% url 'cases:case-detail' report.case.id %}">Case</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-publisher' report.id %}">Report</a>
+                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-publisher' report.id %}">Report publisher</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
                 Edit report
@@ -30,7 +30,7 @@
             <div class="govuk-grid-column-one-half">
                 <div class="govuk-button-group custom-button-group-right">
                     <a
-                        href="{% url 'reports:report-confirm-refresh' report.id %}?return_to=report-detail"
+                        href="{% url 'reports:report-confirm-refresh' report.id %}?return_to=edit-report"
                         role="button"
                         draggable="false"
                         class="govuk-button govuk-button--warning"

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
@@ -35,7 +35,7 @@
                         Publish HTML report
                     </a>
                     <a
-                        href="{% url 'reports:report-detail' report.id %}"
+                        href="{% url 'reports:edit-report' report.id %}"
                         role="button"
                         draggable="false"
                         class="govuk-button govuk-button--secondary"

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/report_visits_metrics.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/report_visits_metrics.html
@@ -17,7 +17,10 @@
                 <a class="govuk-breadcrumbs__link" href="{% url 'cases:case-detail' report.case.id %}">Case</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-publisher' report.id %}">Report</a>
+                <a class="govuk-breadcrumbs__link" href="{% url 'reports:report-publisher' report.id %}">Report publisher</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link" href="{% url 'reports:edit-report' report.id %}">Edit report</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
                 Report visit logs

--- a/accessibility_monitoring_platform/apps/reports/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/reports/tests/test_views.py
@@ -23,7 +23,13 @@ from ...cases.models import (
 )
 from ...s3_read_write.models import S3Report
 
-from ..models import Report, TableRow, Section, ReportVisitsMetrics, TEMPLATE_TYPE_ISSUES_TABLE
+from ..models import (
+    Report,
+    TableRow,
+    Section,
+    ReportVisitsMetrics,
+    TEMPLATE_TYPE_ISSUES_TABLE,
+)
 from ..utils import (
     DELETE_ROW_BUTTON_PREFIX,
     UNDELETE_ROW_BUTTON_PREFIX,
@@ -70,7 +76,7 @@ def test_create_report_redirects(admin_client):
 @pytest.mark.parametrize(
     "return_to, expected_redirect",
     [
-        ("report-detail", "reports:report-detail"),
+        ("edit-report", "reports:edit-report"),
         ("report-publisher", "reports:report-publisher"),
         ("", "reports:report-publisher"),
     ],
@@ -130,7 +136,7 @@ def test_report_published_message_shown(admin_client):
 @pytest.mark.parametrize(
     "path_name, expected_header",
     [
-        ("reports:report-detail", ">Edit report</h1>"),
+        ("reports:edit-report", ">Edit report</h1>"),
         ("reports:edit-report-metadata", ">Report metadata</h1>"),
         ("reports:report-publisher", f"<p>{SECTION_CONTENT}</p>"),
         (
@@ -231,7 +237,7 @@ def test_report_edit_metadata_redirects_to_details(admin_client):
     )
 
     assert response.status_code == 302
-    assert response.url == reverse("reports:report-detail", kwargs=report_pk_kwargs)  # type: ignore
+    assert response.url == reverse("reports:edit-report", kwargs=report_pk_kwargs)  # type: ignore
 
 
 @pytest.mark.django_db
@@ -282,7 +288,7 @@ def test_report_edit_section_redirects_to_details(admin_client):
     )
 
     assert response.status_code == 302
-    assert response.url == reverse("reports:report-detail", kwargs=report_pk_kwargs)  # type: ignore
+    assert response.url == reverse("reports:edit-report", kwargs=report_pk_kwargs)  # type: ignore
 
 
 @pytest.mark.parametrize(
@@ -569,7 +575,7 @@ def test_issues_section_edit_page_contains_warning(admin_client):
     """
     report: Report = create_report()
     audit_pk_kwargs: Dict[str, int] = {"pk": report.case.audit.id}
-    test_details_url: str = reverse('audits:audit-detail', kwargs=audit_pk_kwargs)
+    test_details_url: str = reverse("audits:audit-detail", kwargs=audit_pk_kwargs)
     section: Section = create_section(report)
     section.template_type = TEMPLATE_TYPE_ISSUES_TABLE
     section.save()

--- a/accessibility_monitoring_platform/apps/reports/urls.py
+++ b/accessibility_monitoring_platform/apps/reports/urls.py
@@ -43,9 +43,9 @@ urlpatterns: List[URLPattern] = [
         name="report-publisher",
     ),
     path(
-        "<int:pk>/detail/",
+        "<int:pk>/edit-report/",
         login_required(ReportDetailView.as_view()),
-        name="report-detail",
+        name="edit-report",
     ),
     path(
         "<int:pk>/edit-report-metadata/",

--- a/accessibility_monitoring_platform/apps/reports/views.py
+++ b/accessibility_monitoring_platform/apps/reports/views.py
@@ -72,7 +72,7 @@ def rebuild_report(
     report: Report = get_object_or_404(Report, id=pk)
     generate_report_content(report=report)
     return_to: str = request.GET.get("return_to", "report-publisher")
-    if return_to != "report-detail" and return_to != "report-publisher":
+    if return_to != "edit-report" and return_to != "report-publisher":
         return_to = "report-publisher"
     return redirect(reverse(f"reports:{return_to}", kwargs={"pk": pk}))
 
@@ -84,9 +84,10 @@ class ReportDetailView(DetailView):
 
     model: Type[Report] = Report
     context_object_name: str = "report"
+    template_name: str = "reports/report_edit.html"
 
     def get_context_data(self, **kwargs) -> Dict[str, Any]:
-        """Add undeleted contacts to context"""
+        """Add report visits metrics context"""
         context: Dict[str, Any] = super().get_context_data(**kwargs)
         context.update(get_report_visits_metrics(self.object.case))  # type: ignore
         return context
@@ -126,7 +127,7 @@ class ReportMetadataUpdateView(ReportUpdateView):
         """Detect the submit button used and act accordingly"""
         if "save_exit" in self.request.POST:
             report_pk: Dict[str, int] = {"pk": self.object.id}  # type: ignore
-            return reverse("reports:report-detail", kwargs=report_pk)
+            return reverse("reports:edit-report", kwargs=report_pk)
         return super().get_success_url()
 
 
@@ -211,7 +212,7 @@ class SectionUpdateView(ReportUpdateView):
                 return f"{self.request.path}#row-{updated_table_row_id}"
         if "save_exit" in self.request.POST:
             report_pk: Dict[str, int] = {"pk": self.object.report.id}  # type: ignore
-            return reverse("reports:report-detail", kwargs=report_pk)
+            return reverse("reports:edit-report", kwargs=report_pk)
         if "add_row" in self.request.POST:
             section_pk: Dict[str, int] = {"pk": self.object.id}  # type: ignore
             url: str = reverse("reports:edit-report-section", kwargs=section_pk)


### PR DESCRIPTION
Trello card [#939](https://trello.com/c/FW5oNSY1/939-fix-edit-report-breadcrumbs).