### PR TITLE
946: Use breadcrumb-style labels for links to pages.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/no_psb_response_notification.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/no_psb_response_notification.html
@@ -15,8 +15,9 @@
             Case > Report correspondence > Public sector body is unresponsive
         </h3>
         <p class="govuk-body">
+            Go to
             <a href="{% url 'cases:edit-no-psb-response' audit.case.id %}" class="govuk-link govuk-link--no-visited-state">
-                Go to Case > Report correspondence > Public sector body is unresponsive</a>
+                Case > Report correspondence > Public sector body is unresponsive</a>
         </p>
     </div>
 </div>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
@@ -45,8 +45,9 @@
                 </p>
                 {% if case.report_methodology == 'platform' and case.s3report_set.count == 0 %}
                     <p class="govuk-body-m">
-                        A published report does not exist for this case. Create a report in
+                        A published report does not exist for this case.
                         {% if case.report %}
+                            Publish report in
                             <a
                                 href="{% url 'reports:report-publisher' case.report.id %}"
                                 class="govuk-link govuk-link--no-visited-state"
@@ -54,6 +55,7 @@
                                 Case > Report publisher
                             </a>
                         {% else %}
+                            Create a report in
                             <a
                                 href="{% url 'cases:edit-report-details' case.id %}"
                                 class="govuk-link govuk-link--no-visited-state"

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
@@ -51,14 +51,14 @@
                                 href="{% url 'reports:report-publisher' case.report.id %}"
                                 class="govuk-link govuk-link--no-visited-state"
                             >
-                                case > report
+                                Case > Report publisher
                             </a>
                         {% else %}
                             <a
                                 href="{% url 'cases:edit-report-details' case.id %}"
                                 class="govuk-link govuk-link--no-visited-state"
                             >
-                                case > report details
+                                Case > Report details
                             </a>
                     {% endif %}
                     </p>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_details.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_details.html
@@ -34,6 +34,7 @@
                             {% if case.audit %}
                                 {% if case.report %}
                                     <div class="govuk-button-group">
+                                        Go to
                                         <a
                                             href="{% url 'reports:report-publisher' case.report.id %}"
                                             role="button"
@@ -41,7 +42,7 @@
                                             class="govuk-button govuk-button--secondary"
                                             data-module="govuk-button"
                                         >
-                                            Go to report publisher
+                                            Case > Report publisher
                                         </a>
                                     </div>
                                     <table class="govuk-table">

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/compliant_website_notification.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/compliant_website_notification.html
@@ -20,8 +20,10 @@
                         <h3 class="govuk-notification-banner__heading amp-max-width-100">
                             Select ‘Case should not be sent to the equality body’ in Closing the case and save.
                         </h3>
-                        <p class="govuk-body"><a class="govuk-notification-banner__link" href="{% url 'cases:edit-case-close' case.id %}">
-                            Go to Case > Closing the case</a></p>
+                        <p class="govuk-body">
+                            Go to
+                            <a class="govuk-notification-banner__link" href="{% url 'cases:edit-case-close' case.id %}">
+                            Case > Closing the case</a></p>
                     {% endif %}
                 </div>
             </div>

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -2266,7 +2266,7 @@ def test_platform_report_correspondence_shows_link_to_report_if_none_published(
     assertContains(
         response,
         f"""<p class="govuk-body-m">
-            A published report does not exist for this case. Create a report in
+            A published report does not exist for this case. Publish report in
             <a href="{report_publisher_url}" class="govuk-link govuk-link--no-visited-state">
                 Case > Report publisher
             </a>

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -2268,7 +2268,7 @@ def test_platform_report_correspondence_shows_link_to_report_if_none_published(
         f"""<p class="govuk-body-m">
             A published report does not exist for this case. Create a report in
             <a href="{report_publisher_url}" class="govuk-link govuk-link--no-visited-state">
-                case > report
+                Case > Report publisher
             </a>
         </p>""",
         html=True,
@@ -2510,7 +2510,7 @@ def test_report_corespondence_shows_link_to_create_report(admin_client):
         f"""<p class="govuk-body-m">
             A published report does not exist for this case. Create a report in
             <a href="{report_details_url}" class="govuk-link govuk-link--no-visited-state">
-                case > report details
+                Case > Report details
             </a>
         </p>""",
         html=True,

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/awaiting_approval_notification.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/awaiting_approval_notification.html
@@ -8,7 +8,9 @@
         <h3 class="govuk-notification-banner__heading full-max-width">
             The report is waiting to be approved by the QA auditor.
         </h3>
-        <p class="govuk-body"><a class="govuk-notification-banner__link" href="{% url 'cases:edit-qa-process' report.case.id %}">
-            Go to QA process</a></p>
+        <p class="govuk-body">
+            Co to
+            <a class="govuk-notification-banner__link" href="{% url 'cases:edit-qa-process' report.case.id %}">
+            Case > QA process</a></p>
     </div>
 </div>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/awaiting_approval_notification.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/awaiting_approval_notification.html
@@ -9,7 +9,7 @@
             The report is waiting to be approved by the QA auditor.
         </h3>
         <p class="govuk-body">
-            Co to
+            Go to
             <a class="govuk-notification-banner__link" href="{% url 'cases:edit-qa-process' report.case.id %}">
             Case > QA process</a></p>
     </div>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/pending_published_rebuild_notification.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/pending_published_rebuild_notification.html
@@ -18,11 +18,13 @@
                         <li>Publish a new report</li>
                     </ul>
                     <p class="govuk-body">
+                        Go to
                         <a class="govuk-notification-banner__link" href="{% url 'reports:report-confirm-refresh' case.report.id %}">
-                            Go to Case > Report > Report reset</a></p>
+                            Case > Report > Report reset</a></p>
                     <p class="govuk-body">
+                        Go to
                         <a class="govuk-notification-banner__link" href="{% url 'reports:report-confirm-publish' case.report.id %}">
-                            Go to Case > Report > Publish HTML report</a></p>
+                            Case > Report > Publish HTML report</a></p>
                     <p class="govuk-body">
                         <a class="govuk-notification-banner__link" href="{% url 'audits:clear-outdated-published-report-warning' case.audit.id %}?redirect_destination={{ request.path }}">
                             Dismiss this banner</a></p>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/pending_unpublished_rebuild_notification.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/pending_unpublished_rebuild_notification.html
@@ -13,8 +13,9 @@
                     </h3>
                     <p class="govuk-body">To update the report with the most up to date data, reset the report.</p>
                     <p class="govuk-body">
+                        Go to
                         <a class="govuk-notification-banner__link" href="{% url 'reports:report-confirm-refresh' case.report.id %}">
-                            Go to Case > Report > Report reset</a></p>
+                            Case > Report > Report reset</a></p>
                 </div>
             </div>
         </div>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/qa_process_notification.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/qa_process_notification.html
@@ -11,7 +11,9 @@
         <h3 class="govuk-notification-banner__heading full-max-width">
             If this report is ready to be reviewed, mark 'Report ready to be reviewed' in QA process.
         </h3>
-        <p class="govuk-body"><a class="govuk-notification-banner__link" href="{% url 'cases:edit-qa-process' report.case.id %}">
-            Go to QA process</a></p>
+        <p class="govuk-body">
+            Go to
+            <a class="govuk-notification-banner__link" href="{% url 'cases:edit-qa-process' report.case.id %}">
+            Case > QA process</a></p>
     </div>
 </div>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/s3_report_notification.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/s3_report_notification.html
@@ -15,7 +15,9 @@
                 latest published HTML report</a>
             for {{ report.case.organisation_name }}.
         </h3>
-        <p class="govuk-body"><a class="govuk-notification-banner__link" href="{% url 'cases:edit-qa-process' report.case.id %}">
-            Go to QA process</a></p>
+        <p class="govuk-body">
+            Go to
+            <a class="govuk-notification-banner__link" href="{% url 'cases:edit-qa-process' report.case.id %}">
+            Case > QA process</a></p>
     </div>
 </div>

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/report_confirm_publish.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/report_confirm_publish.html
@@ -54,7 +54,7 @@
                             <a
                                 href="{% url 'cases:edit-qa-process' report.case.id %}"
                                 class="govuk-link govuk-link--no-visited-state">
-                                case > QA process
+                                Case > QA process
                             </a>
                             {% if report.case.report_review_status == 'ready-to-review' %}&check;{% endif %}
                         </li>

--- a/stack_tests/integration_tests/test_1.py
+++ b/stack_tests/integration_tests/test_1.py
@@ -1515,7 +1515,7 @@ class TestCaseReportsUI(TestCase):
     def test_update_report(self):
         """Tests whether report can be updated"""
         self.driver.find_element("link text", "Edit report details").click()
-        self.driver.find_element("link text", "Go to report publisher").click()
+        self.driver.find_element("link text", "Case > Report publisher").click()
         self.driver.find_element("link text", "Edit report").click()
 
         self.driver.find_elements("link text", "Edit")[1].click()
@@ -1613,7 +1613,7 @@ class TestCasePublishReport(TestCase):
     def test_publish_report(self):
         """Tests whether report can be published"""
         self.driver.find_element("link text", "Edit report details").click()
-        self.driver.find_element("link text", "Go to report publisher").click()
+        self.driver.find_element("link text", "Case > Report publisher").click()
 
         self.driver.find_element("link text", "Publish HTML report").click()
         self.assertTrue(


### PR DESCRIPTION
Trello card [#946](https://trello.com/c/gAcKZrm4/946-make-link-labels-consistent).