### PR TITLE
950: Put PDF page at end of lists in report and UI.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -5,6 +5,7 @@ from datetime import date
 from typing import Dict, List, Tuple
 
 from django.db import models
+from django.db.models import Case as DjangoCase, Count, When
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django.utils import timezone
@@ -557,7 +558,9 @@ class Audit(VersionModel):
 
     @property
     def every_page(self):
-        return self.page_audit.filter(is_deleted=False)  # type: ignore
+        return self.page_audit.filter(is_deleted=False).annotate(
+            position_pdfs_last=Count(DjangoCase(When(page_type=PAGE_TYPE_PDF, then=999)))
+        ).order_by("position_pdfs_last")
 
     @property
     def testable_pages(self):

--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -5,7 +5,7 @@ from datetime import date
 from typing import Dict, List, Tuple
 
 from django.db import models
-from django.db.models import Case as DjangoCase, Count, When
+from django.db.models import Case as DjangoCase, When
 from django.db.models.query import QuerySet
 from django.urls import reverse
 from django.utils import timezone
@@ -558,9 +558,16 @@ class Audit(VersionModel):
 
     @property
     def every_page(self):
-        return self.page_audit.filter(is_deleted=False).annotate(
-            position_pdfs_last=Count(DjangoCase(When(page_type=PAGE_TYPE_PDF, then=999)))
-        ).order_by("position_pdfs_last")
+        """Sort page of type PDF to be last"""
+        return (
+            self.page_audit.filter(is_deleted=False)
+            .annotate(
+                position_pdfs_last=DjangoCase(
+                    When(page_type=PAGE_TYPE_PDF, then=1), default=0
+                )
+            )
+            .order_by("position_pdfs_last", "id")
+        )
 
     @property
     def testable_pages(self):
@@ -591,7 +598,12 @@ class Audit(VersionModel):
                 page__is_deleted=False,
                 page__not_found=BOOLEAN_FALSE,
             )
-            .order_by("page__id", "wcag_definition__id")
+            .annotate(
+                position_pdf_page_last=DjangoCase(
+                    When(page__page_type=PAGE_TYPE_PDF, then=1), default=0
+                )
+            )
+            .order_by("position_pdf_page_last", "page__id", "wcag_definition__id")
             .select_related("page", "wcag_definition")
             .all()
         )

--- a/accessibility_monitoring_platform/apps/audits/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_models.py
@@ -102,6 +102,14 @@ def test_audit_every_pages_returns_all_pages():
 
 
 @pytest.mark.django_db
+def test_audit_every_pages_returns_pdf_last():
+    """PDF page returned last."""
+    audit: Audit = create_audit_and_pages()
+
+    assert audit.every_page.last().page_type == PAGE_TYPE_PDF
+
+
+@pytest.mark.django_db
 def test_audit_testable_pages_returns_expected_page():
     """
     Deleted, not found and pages without URLs excluded.
@@ -192,6 +200,17 @@ def test_page_all_check_results_returns_check_results():
     assert len(home_page.all_check_results) == 2
     assert home_page.all_check_results[0].type == TEST_TYPE_AXE
     assert home_page.all_check_results[1].type == TEST_TYPE_MANUAL
+
+
+@pytest.mark.django_db
+def test_page_all_check_results_returns_pdf_check_results_last():
+    """
+    Test all_check_results attribute of page returns PDF-page check results last.
+    """
+    audit: Audit = create_audit_and_check_results()
+
+    assert len(audit.failed_check_results) == 3
+    assert audit.failed_check_results.last().page.page_type == PAGE_TYPE_PDF
 
 
 @pytest.mark.django_db

--- a/accessibility_monitoring_platform/apps/audits/views.py
+++ b/accessibility_monitoring_platform/apps/audits/views.py
@@ -86,8 +86,8 @@ STANDARD_PAGE_HEADERS: List[str] = [
     "Home",
     "Contact",
     "Accessibility Statement",
-    "PDF",
     "A Form",
+    "PDF",
 ]
 
 


### PR DESCRIPTION
Trello card [#950](https://trello.com/c/MSWWlFJj/950-move-pdf-in-testing-pages-to-the-bottom-of-the-list).