### PR TITLE
961: Check URL exists before rendering link

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/details/retest_statement.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/details/retest_statement.html
@@ -17,11 +17,14 @@
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header amp-width-one-half">Link to 12-week saved accessibility statement</th>
             <td class="govuk-table__cell amp-width-one-half">
-                <a href="{{ audit.audit_retest_accessibility_statement_backup_url }}"
-                    rel="noreferrer noopener" target="_blank" class="govuk-link">
-                    {{ audit.audit_retest_accessibility_statement_backup_url }}
-                </a>
-
+                {% if audit.audit_retest_accessibility_statement_backup_url %}
+                    <a href="{{ audit.audit_retest_accessibility_statement_backup_url }}"
+                        rel="noreferrer noopener" target="_blank" class="govuk-link">
+                        {{ audit.audit_retest_accessibility_statement_backup_url }}
+                    </a>
+                {% else %}
+                    None
+                {% endif %}
             </td>
         </tr>
         <tr class="govuk-table__row">


### PR DESCRIPTION
Trello card [#961](https://trello.com/c/YiBSKLQb/961-wcag-dont-render-empty-links).