### PR TITLE
964: Redirect to case on save and exit from testing UI

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -279,9 +279,7 @@ def test_audit_specific_page_loads(path_name, expected_content, admin_client):
             "save_continue",
             "audits:edit-audit-report-text",
         ),
-        ("audits:edit-audit-summary", "save_exit", "audits:audit-detail"),
         ("audits:edit-audit-report-text", "save", "audits:edit-audit-report-text"),
-        ("audits:edit-audit-report-text", "save_exit", "audits:audit-detail"),
         (
             "audits:edit-audit-retest-metadata",
             "save",
@@ -362,6 +360,34 @@ def test_audit_edit_redirects_based_on_button_pressed(
     assert response.status_code == 302
 
     expected_path: str = reverse(expected_redirect_path_name, kwargs=audit_pk)
+    assert response.url == expected_path  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "path_name",
+    ["audits:edit-audit-summary", "audits:edit-audit-report-text"],
+)
+def test_audit_edit_redirects_to_case(
+    path_name,
+    admin_client,
+):
+    """Test that a successful audit save and exit redirects to the case"""
+    audit: Audit = create_audit_and_wcag()
+    audit_pk: Dict[str, int] = {"pk": audit.id}  # type: ignore
+    case_pk: Dict[str, int] = {"pk": audit.case.id}  # type: ignore
+
+    response: HttpResponse = admin_client.post(
+        reverse(path_name, kwargs=audit_pk),
+        {
+            "version": audit.version,
+            "save_exit": "Button value",
+            "case-version": audit.case.version,
+        },
+    )
+
+    assert response.status_code == 302
+
+    expected_path: str = reverse("cases:edit-test-results", kwargs=case_pk)
     assert response.url == expected_path  # type: ignore
 
 

--- a/accessibility_monitoring_platform/apps/audits/views.py
+++ b/accessibility_monitoring_platform/apps/audits/views.py
@@ -597,8 +597,9 @@ class AuditSummaryUpdateView(AuditUpdateView):
     def get_success_url(self) -> str:
         """Detect the submit button used and act accordingly"""
         if "save_exit" in self.request.POST:
-            audit_pk: Dict[str, int] = {"pk": self.object.id}  # type: ignore
-            return reverse("audits:audit-detail", kwargs=audit_pk)
+            audit: Audit = self.object
+            case_pk: Dict[str, int] = {"pk": audit.case.id}  # type: ignore
+            return reverse("cases:edit-test-results", kwargs=case_pk)
         if "save_continue" in self.request.POST:
             audit_pk: Dict[str, int] = {"pk": self.object.id}  # type: ignore
             return reverse("audits:edit-audit-report-text", kwargs=audit_pk)
@@ -622,8 +623,9 @@ class AuditReportTextUpdateView(AuditUpdateView):
     def get_success_url(self) -> str:
         """Detect the submit button used and act accordingly"""
         if "save_exit" in self.request.POST:
-            audit_pk: Dict[str, int] = {"pk": self.object.id}  # type: ignore
-            return reverse("audits:audit-detail", kwargs=audit_pk)
+            audit: Audit = self.object
+            case_pk: Dict[str, int] = {"pk": audit.case.id}  # type: ignore
+            return reverse("cases:edit-test-results", kwargs=case_pk)
         return super().get_success_url()
 
 

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
@@ -20,7 +20,7 @@
     <main id="main-content" class="govuk-main-wrapper amp-padding-top-0">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                {% include "cases/helpers/edit_header.html" with page_heading='Report publisher' %}
+                {% include "cases/helpers/edit_header.html" with page_heading='Report publisher' case=report.case %}
             </div>
         </div>
         <div class="govuk-grid-row">


### PR DESCRIPTION
Trello card [#964](https://trello.com/c/akZ4y8ZN/964-change-save-and-exit-in-the-final-step-of-the-testing-ui-to-link-to-testing-details-instead-of-the-testing-overview).