### PR TITLE
957: Hide search icons from the accessibility api.

### DIFF
--- a/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/dashboard.html
+++ b/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard | {{ page_title }}{% endblock %}
+{% block title %}Home | {{ page_title }}{% endblock %}
 
 {% block content %}
 <div class="govuk-width-container">

--- a/accessibility_monitoring_platform/apps/dashboard/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/dashboard/tests/test_views.py
@@ -29,7 +29,7 @@ def test_dashboard_loads_correctly_when_user_logged_in(admin_client):
     response: HttpResponse = admin_client.get(reverse("dashboard:home"))
 
     assert response.status_code == 200
-    assertContains(response, "Dashboard")
+    assertContains(response, "Home |")
 
 
 def test_dashboard_redirects_to_login_when_user_not_logged_in(client):

--- a/accessibility_monitoring_platform/templates/navbar.html
+++ b/accessibility_monitoring_platform/templates/navbar.html
@@ -10,7 +10,6 @@
                         <span class="govuk-visually-hidden">Search:</span>
                         {{ top_menu_form.search }}
                         <button class="govuk-input__suffix amp-search-button">
-                            <span class="govuk-visually-hidden">Search accessibility monitoring platform</span>
                             <svg
                                 aria-hidden="true"
                                 xmlns="http://www.w3.org/2000/svg"

--- a/accessibility_monitoring_platform/templates/navbar.html
+++ b/accessibility_monitoring_platform/templates/navbar.html
@@ -9,19 +9,21 @@
                     <div class="govuk-input__wrapper">
                         <span class="govuk-visually-hidden">Search:</span>
                         {{ top_menu_form.search }}
-                        <button class="govuk-input__suffix amp-search-button" aria-hidden="true">
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 40 40"
-                                    width="40"
-                                    height="40"
-                                    stroke="currentColor"
-                                    stroke-width="3"
-                                    fill="none"
-                                >
-                                    <line x1="22" y1="23" x2="29" y2="31"/>
-                                    <circle cx="18" cy="18" r="8" />
-                                </svg>
+                        <button class="govuk-input__suffix amp-search-button">
+                            <span class="govuk-visually-hidden">Search accessibility monitoring platform</span>
+                            <svg
+                                aria-hidden="true"
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 40 40"
+                                width="40"
+                                height="40"
+                                stroke="currentColor"
+                                stroke-width="3"
+                                fill="none"
+                            >
+                                <line x1="22" y1="23" x2="29" y2="31"/>
+                                <circle cx="18" cy="18" r="8" />
+                            </svg>
                         </button>
                     </div>
                 </div>


### PR DESCRIPTION
Trello card [#957](https://trello.com/c/Azu8Z2ww/957-wcag-buttons-must-have-discernible-text).