### PR TITLE
998: Remove broken redundant test.

### DIFF
--- a/stack_tests/integration_tests/cypress/e2e/audit.cy.js
+++ b/stack_tests/integration_tests/cypress/e2e/audit.cy.js
@@ -100,10 +100,4 @@ describe('View test', () => {
     cy.get('[name="audit_summary_complete_date"]').click()
     cy.contains('Save').click()
   })
-
-  it('can edit report text', () => {
-    cy.contains('a', 'Edit report text').click()
-    cy.get('[name="audit_report_text_complete_date"]').click()
-    cy.contains('Save').click()
-  })
 })


### PR DESCRIPTION
Trello card [#998](https://trello.com/c/P8qfeTtz/998-remove-broken-test).