### PR TITLE
984: Add links to contact and statement pages to contact UI.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -584,6 +584,10 @@ class Audit(VersionModel):
         return self.every_page.filter(page_type=PAGE_TYPE_STATEMENT).first()
 
     @property
+    def contact_page(self):
+        return self.every_page.filter(page_type=PAGE_TYPE_CONTACT).first()
+
+    @property
     def standard_pages(self):
         return self.every_page.exclude(page_type=PAGE_TYPE_EXTRA)
 

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/contact_formset.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/contact_formset.html
@@ -27,6 +27,24 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 {% include 'common/error_summary.html' %}
+                <p class="govuk-body-m">
+                    {% if case.audit.contact_page.url and case.audit.contact_page.not_found == 'no' %}
+                        <a href="{{ case.audit.contact_page.url }}" target="_blank" class="govuk-link">
+                            Open contact page
+                        </a>
+                    {% else %}
+                        No contact page.
+                    {% endif %}
+                </p>
+                <p class="govuk-body-m">
+                    {% if case.audit.accessibility_statement_page.url and case.audit.accessibility_statement_page.not_found == 'no' %}
+                        <a href="{{ case.audit.accessibility_statement_page.url }}" target="_blank" class="govuk-link">
+                            Open accessibility statement page
+                        </a>
+                    {% else %}
+                        No accessibility statement page.
+                    {% endif %}
+                </p>
                 <form method="post" action="{% url 'cases:edit-contact-details' case.id %}">
                     {% csrf_token %}
                     {{ contacts_formset.management_form }}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -2019,7 +2019,9 @@ def test_links_to_contact_and_accessibility_pages_shown(admin_client):
     Page.objects.create(
         audit=audit, page_type=PAGE_TYPE_STATEMENT, url=ACCESSIBILITY_STATEMENT_URL
     )
-    Page.objects.create(audit=audit, page_type=PAGE_TYPE_CONTACT, url=CONTACT_STATEMENT_URL)
+    Page.objects.create(
+        audit=audit, page_type=PAGE_TYPE_CONTACT, url=CONTACT_STATEMENT_URL
+    )
 
     response: HttpResponse = admin_client.get(
         reverse("cases:edit-contact-details", kwargs={"pk": case.id}),  # type: ignore

--- a/accessibility_monitoring_platform/apps/cases/utils.py
+++ b/accessibility_monitoring_platform/apps/cases/utils.py
@@ -88,7 +88,9 @@ COLUMNS_FOR_EHRC: List[ColumnAndFieldNames] = [
         field_name="report_followup_week_12_due_date",
     ),
     ColumnAndFieldNames(column_name="Retest date", field_name="retested_website_date"),
-    ColumnAndFieldNames(column_name="Published report", field_name="published_report_url"),
+    ColumnAndFieldNames(
+        column_name="Published report", field_name="published_report_url"
+    ),
 ]
 
 EXTRA_AUDIT_COLUMNS_FOR_EHRC: List[ColumnAndFieldNames] = [


### PR DESCRIPTION
Trello card [#984](https://trello.com/c/PciPxGwm/984-add-link-to-contact-page-and-statement-in-the-platforms-contact-page-design-attached).