### PR TITLE
985: Hide link to accessibility statement if none exists.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/accessibility_statement_link.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/accessibility_statement_link.html
@@ -1,12 +1,13 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="govuk-body">
-            {% if audit.accessibility_statement_page %}
+            {{ audit.accessibility_statement_page.url }}
+            {% if audit.accessibility_statement_page.url %}
                 <a href="{{ audit.accessibility_statement_page.url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
                     Link to {{ audit.accessibility_statement_page|lower }}
                 </a>
             {% else %}
-                No accessibility statement added. Add page in
+                No accessibility statement found. Add page in
                 <a href="{% url 'audits:edit-audit-pages' audit.id %}" class="govuk-link govuk-link--no-visited-state">
                     pages
                 </a>

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/accessibility_statement_link.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/accessibility_statement_link.html
@@ -1,8 +1,7 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="govuk-body">
-            {{ audit.accessibility_statement_page.url }}
-            {% if audit.accessibility_statement_page.url %}
+            {% if audit.accessibility_statement_page.url and audit.accessibility_statement_page.not_found != 'yes' %}
                 <a href="{{ audit.accessibility_statement_page.url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
                     Link to {{ audit.accessibility_statement_page|lower }}
                 </a>

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -51,6 +51,7 @@ WCAG_DEFINITION_TYPE: str = "axe"
 WCAG_DEFINITION_NAME: str = "WCAG definiton name"
 WCAG_DEFINITION_URL: str = "https://example.com"
 PAGE_RETEST_NOTES: str = "Retest notes"
+ACCESSIBILITY_STATEMENT_URL: str = "https://example.com/accessibility-statement"
 
 
 def create_audit() -> Audit:
@@ -688,6 +689,34 @@ def test_website_decision_saved_on_case(admin_client):
 
     assert updated_case.is_website_compliant == IS_WEBSITE_COMPLIANT
     assert updated_case.compliance_decision_notes == COMPLIANCE_DECISION_NOTES
+
+
+def test_statement_update_one_shows_statement_link(admin_client):
+    """Test that a accessibility statement links shown if present"""
+    audit: Audit = create_audit_and_pages()
+    audit_pk: Dict[str, int] = {"pk": audit.id}  # type: ignore
+
+    response: HttpResponse = admin_client.get(
+        reverse("audits:edit-audit-statement-1", kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, "No accessibility statement found. Add page in")
+    assertNotContains(response, ACCESSIBILITY_STATEMENT_URL)
+
+    page: Page = audit.accessibility_statement_page
+    page.url = ACCESSIBILITY_STATEMENT_URL
+    page.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse("audits:edit-audit-statement-1", kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertNotContains(response, "No accessibility statement found. Add page in")
+    assertContains(response, ACCESSIBILITY_STATEMENT_URL)
 
 
 @pytest.mark.parametrize(

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -718,6 +718,18 @@ def test_statement_update_one_shows_statement_link(admin_client):
     assertNotContains(response, "No accessibility statement found. Add page in")
     assertContains(response, ACCESSIBILITY_STATEMENT_URL)
 
+    page.not_found = BOOLEAN_TRUE
+    page.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse("audits:edit-audit-statement-1", kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, "No accessibility statement found. Add page in")
+    assertNotContains(response, ACCESSIBILITY_STATEMENT_URL)
+
 
 @pytest.mark.parametrize(
     "email, notes, new_contact_expected",


### PR DESCRIPTION
Trello card [#985](https://trello.com/c/ajwNqVkz/985-add-text-next-to-link-for-statement-saying-there-is-no-statement-in-test-ui).