### PR TITLE
1022: Add affects status help text to QA auditor field.

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -329,7 +329,10 @@ class CaseQAProcessUpdateForm(VersionForm):
         choices=REPORT_REVIEW_STATUS_CHOICES,
         help_text="This field affects the case status",
     )
-    reviewer = AMPAuditorModelChoiceField(label="QA Auditor")
+    reviewer = AMPAuditorModelChoiceField(
+        label="QA Auditor",
+        help_text="This field affects the case status",
+    )
     report_approved_status = AMPChoiceRadioField(
         label="Report approved?",
         choices=REPORT_APPROVED_STATUS_CHOICES,


### PR DESCRIPTION
Trello card [#1022](https://trello.com/c/nOpQKt52/1022-add-this-is-required-for-status-help-text-to-qa-auditor-on-the-qa-page).