### PR TITLE
1020: Show page retest notes on comparison page.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/retest_page_comparison.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/retest_page_comparison.html
@@ -15,5 +15,17 @@
             </td>
         </tr>
     {% endfor %}
+    <tr class="govuk-table__row">
+        <td colspan="2" class="govuk-table__cell">
+            <label class="govuk-label"><b>Additional issues found on page</b></label>
+            <div class="govuk-hint">
+                {% if page.retest_notes %}
+                    {{ page.retest_notes|markdown_to_html }}
+                {% else %}
+                    None
+                {% endif %}
+            </div>
+        </td>
+    </tr>
 </tbody>
 

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -877,7 +877,7 @@ def test_retest_details_renders_when_no_psb_response(admin_client):
 def test_retest_page_checks_edit_page_loads(admin_client):
     """Test retest page checks edit view page loads and contains errors"""
     audit: Audit = create_audit_and_wcag()
-    page: Page = Page.objects.create(audit=audit)
+    page: Page = Page.objects.create(audit=audit, retest_notes=PAGE_RETEST_NOTES)
     page_pk: Dict[str, int] = {"pk": page.id}  # type: ignore
     wcag_definition_pdf: WcagDefinition = WcagDefinition.objects.get(type=TEST_TYPE_PDF)
     wcag_definition_axe: WcagDefinition = WcagDefinition.objects.get(type=TEST_TYPE_AXE)
@@ -901,6 +901,7 @@ def test_retest_page_checks_edit_page_loads(admin_client):
     assert response.status_code == 200
 
     assertContains(response, "Retesting Additional")
+    assertContains(response, PAGE_RETEST_NOTES)
     assertContains(response, WCAG_TYPE_AXE_NAME)
     assertContains(response, WCAG_TYPE_PDF_NAME)
 

--- a/stack_tests/integration_tests/fixtures/audits.json
+++ b/stack_tests/integration_tests/fixtures/audits.json
@@ -120,7 +120,8 @@
         "no_errors_date": null,
         "not_found": "no",
         "retest_complete_date": null,
-        "retest_page_missing_date": null
+        "retest_page_missing_date": null,
+        "retest_notes": "In a hole in the ground there lived a hobbit."
     }
 },
 {


### PR DESCRIPTION
Trello card [#1020](https://trello.com/c/C2bMf1mI/1020-add-additional-issues-to-the-summary-page).