### PR TITLE
1021: Hide accessibility statement details when no such page.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -589,7 +589,7 @@ class Audit(VersionModel):
     @property
     def no_accessibility_statement_found(self):
         page: Page = self.every_page.filter(page_type=PAGE_TYPE_STATEMENT).first()
-        return page is None or page.not_found == BOOLEAN_TRUE or page.url == ""
+        return page is None or page.url == "" or page.not_found == BOOLEAN_TRUE
 
     @property
     def contact_page(self):

--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -587,9 +587,9 @@ class Audit(VersionModel):
         return self.every_page.filter(page_type=PAGE_TYPE_STATEMENT).first()
 
     @property
-    def no_accessibility_statement_found(self):
+    def accessibility_statement_found(self):
         page: Page = self.every_page.filter(page_type=PAGE_TYPE_STATEMENT).first()
-        return page is None or page.url == "" or page.not_found == BOOLEAN_TRUE
+        return page is not None and page.url != "" and page.not_found == BOOLEAN_FALSE
 
     @property
     def contact_page(self):

--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -587,6 +587,11 @@ class Audit(VersionModel):
         return self.every_page.filter(page_type=PAGE_TYPE_STATEMENT).first()
 
     @property
+    def no_accessibility_statement_found(self):
+        page: Page = self.every_page.filter(page_type=PAGE_TYPE_STATEMENT).first()
+        return page is None or page.not_found == BOOLEAN_TRUE or page.url == ""
+
+    @property
     def contact_page(self):
         return self.every_page.filter(page_type=PAGE_TYPE_CONTACT).first()
 

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/details/retest_statement.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/details/retest_statement.html
@@ -12,228 +12,232 @@
         </div>
     </div>
 </div>
-<table class="govuk-table">
-    <tbody class="govuk-table__body">
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Link to 12-week saved accessibility statement</th>
-            <td class="govuk-table__cell amp-width-one-half">
-                {% if audit.audit_retest_accessibility_statement_backup_url %}
-                    <a href="{{ audit.audit_retest_accessibility_statement_backup_url }}"
-                        rel="noreferrer noopener" target="_blank" class="govuk-link">
-                        {{ audit.audit_retest_accessibility_statement_backup_url }}
-                    </a>
-                {% else %}
-                    None
-                {% endif %}
-            </td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original scope state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_scope_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original scope notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.scope_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest scope state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_scope_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest scope notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_scope_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original feedback state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_feedback_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original feedback notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.feedback_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest feedback state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_feedback_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest feedback notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_feedback_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original contact information state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_contact_information_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original contact information notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.contact_information_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest contact information state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_contact_information_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest contact information notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_contact_information_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original enforcement procedure state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_enforcement_procedure_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original enforcement procedure notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.enforcement_procedure_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest enforcement procedure state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_enforcement_procedure_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest enforcement procedure notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_enforcement_procedure_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original declaration state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_declaration_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original declaration notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.declaration_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest declaration state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_declaration_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest declaration notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_declaration_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original compliance status state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_compliance_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original compliance status notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.compliance_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest compliance status state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_compliance_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest compliance status notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_compliance_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - non compliance with regulations state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_non_regulation_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - non compliance with regulations notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.non_regulation_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - non compliance with regulations state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_non_regulation_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - non compliance with regulations notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_non_regulation_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - disproportionate burden' state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_disproportionate_burden_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - disproportionate burden' notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.disproportionate_burden_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - disproportionate burden' state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_disproportionate_burden_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - disproportionate burden' notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_disproportionate_burden_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - the content is not within the scope of the applicable legislation state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_content_not_in_scope_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - the content is not within the scope of the applicable legislation notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.content_not_in_scope_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - the content is not within the scope of the applicable legislation state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_content_not_in_scope_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - the content is not within the scope of the applicable legislation notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_content_not_in_scope_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original preparation date state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_preparation_date_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original preparation date notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.preparation_date_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest preparation date state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_preparation_date_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest preparation date notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_preparation_date_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original review state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_review_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original review notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.review_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest review state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_review_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest review notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_review_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original method state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_method_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original method notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.method_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest method state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_method_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest method notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_method_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original access requirements state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_access_requirements_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Original access requirements notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.access_requirements_notes|markdown_to_html }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest access requirements state</th>
-            <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_access_requirements_state_display }}</td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__header amp-width-one-half">Retest access requirements notes</th>
-            <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_access_requirements_notes|markdown_to_html }}</td>
-        </tr>
-    </tbody>
-</table>
+{% if audit.no_accessibility_statement_found %}
+    {% include 'audits/helpers/no_statement_warning.html' %}
+{% else %}
+    <table class="govuk-table">
+        <tbody class="govuk-table__body">
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Link to 12-week saved accessibility statement</th>
+                <td class="govuk-table__cell amp-width-one-half">
+                    {% if audit.audit_retest_accessibility_statement_backup_url %}
+                        <a href="{{ audit.audit_retest_accessibility_statement_backup_url }}"
+                            rel="noreferrer noopener" target="_blank" class="govuk-link">
+                            {{ audit.audit_retest_accessibility_statement_backup_url }}
+                        </a>
+                    {% else %}
+                        None
+                    {% endif %}
+                </td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original scope state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_scope_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original scope notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.scope_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest scope state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_scope_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest scope notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_scope_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original feedback state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_feedback_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original feedback notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.feedback_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest feedback state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_feedback_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest feedback notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_feedback_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original contact information state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_contact_information_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original contact information notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.contact_information_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest contact information state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_contact_information_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest contact information notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_contact_information_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original enforcement procedure state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_enforcement_procedure_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original enforcement procedure notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.enforcement_procedure_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest enforcement procedure state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_enforcement_procedure_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest enforcement procedure notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_enforcement_procedure_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original declaration state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_declaration_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original declaration notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.declaration_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest declaration state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_declaration_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest declaration notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_declaration_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original compliance status state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_compliance_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original compliance status notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.compliance_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest compliance status state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_compliance_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest compliance status notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_compliance_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - non compliance with regulations state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_non_regulation_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - non compliance with regulations notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.non_regulation_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - non compliance with regulations state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_non_regulation_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - non compliance with regulations notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_non_regulation_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - disproportionate burden state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_disproportionate_burden_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - disproportionate burden notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.disproportionate_burden_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - disproportionate burden state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_disproportionate_burden_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - disproportionate burden notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_disproportionate_burden_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - the content is not within the scope of the applicable legislation state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_content_not_in_scope_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original non-accessible content - the content is not within the scope of the applicable legislation notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.content_not_in_scope_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - the content is not within the scope of the applicable legislation state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_content_not_in_scope_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest non-accessible content - the content is not within the scope of the applicable legislation notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_content_not_in_scope_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original preparation date state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_preparation_date_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original preparation date notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.preparation_date_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest preparation date state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_preparation_date_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest preparation date notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_preparation_date_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original review state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_review_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original review notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.review_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest review state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_review_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest review notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_review_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original method state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_method_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original method notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.method_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest method state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_method_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest method notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_method_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original access requirements state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_access_requirements_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Original access requirements notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.access_requirements_notes|markdown_to_html }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest access requirements state</th>
+                <td class="govuk-table__cell amp-width-one-half">{{ audit.get_audit_retest_access_requirements_state_display }}</td>
+            </tr>
+            <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header amp-width-one-half">Retest access requirements notes</th>
+                <td class="govuk-table__cell amp-width-one-half amp-notes">{{ audit.audit_retest_access_requirements_notes|markdown_to_html }}</td>
+            </tr>
+        </tbody>
+    </table>
+{% endif %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/details/retest_statement.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/details/retest_statement.html
@@ -12,9 +12,7 @@
         </div>
     </div>
 </div>
-{% if audit.no_accessibility_statement_found %}
-    {% include 'audits/helpers/no_statement_warning.html' %}
-{% else %}
+{% if audit.accessibility_statement_found %}
     <table class="govuk-table">
         <tbody class="govuk-table__body">
             <tr class="govuk-table__row">
@@ -240,4 +238,6 @@
             </tr>
         </tbody>
     </table>
+{% else %}
+    {% include 'audits/helpers/no_statement_warning.html' %}
 {% endif %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/details/statement.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/details/statement.html
@@ -10,10 +10,14 @@
         </div>
     </div>
 </div>
-<table class="govuk-table">
-    <tbody class="govuk-table__body">
-        {% for row in audit_statement_rows %}
-            {% include 'cases/helpers/detail_row.html' with row=row %}
-        {% endfor %}
-    </tbody>
-</table>
+{% if audit.no_accessibility_statement_found %}
+    {% include 'audits/helpers/no_statement_warning.html' %}
+{% else %}
+    <table class="govuk-table">
+        <tbody class="govuk-table__body">
+            {% for row in audit_statement_rows %}
+                {% include 'cases/helpers/detail_row.html' with row=row %}
+            {% endfor %}
+        </tbody>
+    </table>
+{% endif %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/details/statement.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/details/statement.html
@@ -10,9 +10,7 @@
         </div>
     </div>
 </div>
-{% if audit.no_accessibility_statement_found %}
-    {% include 'audits/helpers/no_statement_warning.html' %}
-{% else %}
+{% if audit.accessibility_statement_found %}
     <table class="govuk-table">
         <tbody class="govuk-table__body">
             {% for row in audit_statement_rows %}
@@ -20,4 +18,6 @@
             {% endfor %}
         </tbody>
     </table>
+{% else %}
+    {% include 'audits/helpers/no_statement_warning.html' %}
 {% endif %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
@@ -37,14 +37,12 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% if not audit.no_accessibility_statement_found %}
+                    {% if audit.accessibility_statement_found %}
                         {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=1 %}
                     {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% if audit.no_accessibility_statement_found %}
-                                {% include 'audits/helpers/no_statement_warning.html' %}
-                            {% else %}
+                            {% if audit.accessibility_statement_found %}
                                 {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
                                 {% if audit.audit_retest_accessibility_statement_backup_url_date %}
                                     <p class="govuk-body amp-margin-top-minus-20">Added {{ audit.audit_retest_accessibility_statement_backup_url_date }}</p>
@@ -75,9 +73,11 @@
                                 {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - non compliance with regulations' example='audits/statement_examples/non_regulation_state.html' decision=audit.get_non_regulation_state_display notes=audit.non_regulation_notes %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_non_regulation_state %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_non_regulation_notes %}
+                            {% else %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
                             {% endif %}
                             {% include 'common/amp_field.html' with field=form.audit_retest_statement_1_complete_date %}
-                            </div>
+                        </div>
                         <div class="govuk-grid-column-full govuk-button-group">
                             {% include 'audits/helpers/save_continue_cancel.html' %}
                         </div>

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
@@ -37,41 +37,47 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=1 %}
+                    {% if not audit.no_accessibility_statement_found %}
+                        {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=1 %}
+                    {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
-                            {% if audit.audit_retest_accessibility_statement_backup_url_date %}
-                                <p class="govuk-body amp-margin-top-minus-20">Added {{ audit.audit_retest_accessibility_statement_backup_url_date }}</p>
+                            {% if audit.no_accessibility_statement_found %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
+                            {% else %}
+                                {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
+                                {% if audit.audit_retest_accessibility_statement_backup_url_date %}
+                                    <p class="govuk-body amp-margin-top-minus-20">Added {{ audit.audit_retest_accessibility_statement_backup_url_date }}</p>
+                                {% endif %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Scope' example='audits/statement_examples/scope_state.html' decision=audit.get_scope_state_display notes=audit.scope_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_scope_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_scope_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Feedback' example='audits/statement_examples/feedback_state.html' decision=audit.get_feedback_state_display notes=audit.feedback_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_feedback_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_feedback_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Contact Information' example='audits/statement_examples/contact_information_state.html' decision=audit.get_contact_information_state_display notes=audit.contact_information_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_contact_information_state %}
+                                <p class="govuk-body-m">
+                                    <a href="{% url 'cases:edit-contact-details' audit.case.id %}"
+                                        rel="noreferrer noopener" target="_blank" class="govuk-link govuk-link--no-visited-state">
+                                        Open contact details page in new tab</a>
+                                </p>
+                                {% include 'common/amp_field.html' with field=form.audit_retest_contact_information_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Enforcement Procedure' example='audits/statement_examples/enforcement_procedure_state.html' decision=audit.get_enforcement_procedure_state_display notes=audit.enforcement_procedure_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_enforcement_procedure_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_enforcement_procedure_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Declaration' example='audits/statement_examples/declaration_state.html' decision=audit.get_declaration_state_display notes=audit.declaration_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_declaration_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_declaration_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Compliance Status' example='audits/statement_examples/compliance_state.html' decision=audit.get_compliance_state_display notes=audit.compliance_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_compliance_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_compliance_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - non compliance with regulations' example='audits/statement_examples/non_regulation_state.html' decision=audit.get_non_regulation_state_display notes=audit.non_regulation_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_non_regulation_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_non_regulation_notes %}
                             {% endif %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Scope' example='audits/statement_examples/scope_state.html' decision=audit.get_scope_state_display notes=audit.scope_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_scope_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_scope_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Feedback' example='audits/statement_examples/feedback_state.html' decision=audit.get_feedback_state_display notes=audit.feedback_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_feedback_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_feedback_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Contact Information' example='audits/statement_examples/contact_information_state.html' decision=audit.get_contact_information_state_display notes=audit.contact_information_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_contact_information_state %}
-                            <p class="govuk-body-m">
-                                <a href="{% url 'cases:edit-contact-details' audit.case.id %}"
-                                    rel="noreferrer noopener" target="_blank" class="govuk-link govuk-link--no-visited-state">
-                                    Open contact details page in new tab</a>
-                            </p>
-                            {% include 'common/amp_field.html' with field=form.audit_retest_contact_information_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Enforcement Procedure' example='audits/statement_examples/enforcement_procedure_state.html' decision=audit.get_enforcement_procedure_state_display notes=audit.enforcement_procedure_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_enforcement_procedure_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_enforcement_procedure_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Declaration' example='audits/statement_examples/declaration_state.html' decision=audit.get_declaration_state_display notes=audit.declaration_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_declaration_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_declaration_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Compliance Status' example='audits/statement_examples/compliance_state.html' decision=audit.get_compliance_state_display notes=audit.compliance_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_compliance_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_compliance_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - non compliance with regulations' example='audits/statement_examples/non_regulation_state.html' decision=audit.get_non_regulation_state_display notes=audit.non_regulation_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_non_regulation_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_non_regulation_notes %}
                             {% include 'common/amp_field.html' with field=form.audit_retest_statement_1_complete_date %}
-                        </div>
+                            </div>
                         <div class="govuk-grid-column-full govuk-button-group">
                             {% include 'audits/helpers/save_continue_cancel.html' %}
                         </div>

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_2.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_2.html
@@ -37,14 +37,12 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% if not audit.no_accessibility_statement_found %}
+                    {% if audit.accessibility_statement_found %}
                         {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=1 %}
                     {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% if audit.no_accessibility_statement_found %}
-                                {% include 'audits/helpers/no_statement_warning.html' %}
-                            {% else %}
+                            {% if audit.accessibility_statement_found %}
                                 {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
                                 {% if audit.audit_retest_accessibility_statement_backup_url_date %}
                                     <p class="govuk-body amp-margin-top-minus-20"> Added {{audit.audit_retest_accessibility_statement_backup_url_date}} </p>
@@ -67,6 +65,8 @@
                                 {% include 'audits/helpers/retest_statement_field_info.html' with name='Access Requirements' example='audits/statement_examples/access_requirements_state.html' decision=audit.get_access_requirements_state_display notes=audit.access_requirements_notes %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_access_requirements_state %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_access_requirements_notes %}
+                            {% else %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
                             {% endif %}
                             {% include 'common/amp_field.html' with field=form.audit_retest_statement_2_complete_date %}
                         </div>

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_2.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_2.html
@@ -37,31 +37,37 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=1 %}
+                    {% if not audit.no_accessibility_statement_found %}
+                        {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=1 %}
+                    {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
-                            {% if audit.audit_retest_accessibility_statement_backup_url_date %}
-                                <p class="govuk-body amp-margin-top-minus-20"> Added {{audit.audit_retest_accessibility_statement_backup_url_date}} </p>
+                            {% if audit.no_accessibility_statement_found %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
+                            {% else %}
+                                {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
+                                {% if audit.audit_retest_accessibility_statement_backup_url_date %}
+                                    <p class="govuk-body amp-margin-top-minus-20"> Added {{audit.audit_retest_accessibility_statement_backup_url_date}} </p>
+                                {% endif %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - disproportionate burden' example='audits/statement_examples/disproportionate_burden_state.html' decision=audit.get_disproportionate_burden_state_display notes=audit.disproportionate_burden_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_disproportionate_burden_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_disproportionate_burden_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - the content is not within the scope of the applicable legislation' example='audits/statement_examples/content_not_in_scope_state.html' decision=audit.get_content_not_in_scope_state_display notes=audit.content_not_in_scope_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_content_not_in_scope_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_content_not_in_scope_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Preparation Date' example='audits/statement_examples/preparation_date_state.html' decision=audit.get_preparation_date_state_display notes=audit.preparation_date_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_preparation_date_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_preparation_date_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Review' example='audits/statement_examples/review_state.html' decision=audit.get_review_state_display notes=audit.review_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_review_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_review_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Method' example='audits/statement_examples/method_state.html' decision=audit.get_method_state_display notes=audit.method_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_method_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_method_notes %}
+                                {% include 'audits/helpers/retest_statement_field_info.html' with name='Access Requirements' example='audits/statement_examples/access_requirements_state.html' decision=audit.get_access_requirements_state_display notes=audit.access_requirements_notes %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_access_requirements_state %}
+                                {% include 'common/amp_field.html' with field=form.audit_retest_access_requirements_notes %}
                             {% endif %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - disproportionate burden' example='audits/statement_examples/disproportionate_burden_state.html' decision=audit.get_disproportionate_burden_state_display notes=audit.disproportionate_burden_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_disproportionate_burden_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_disproportionate_burden_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - the content is not within the scope of the applicable legislation' example='audits/statement_examples/content_not_in_scope_state.html' decision=audit.get_content_not_in_scope_state_display notes=audit.content_not_in_scope_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_content_not_in_scope_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_content_not_in_scope_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Preparation Date' example='audits/statement_examples/preparation_date_state.html' decision=audit.get_preparation_date_state_display notes=audit.preparation_date_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_preparation_date_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_preparation_date_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Review' example='audits/statement_examples/review_state.html' decision=audit.get_review_state_display notes=audit.review_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_review_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_review_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Method' example='audits/statement_examples/method_state.html' decision=audit.get_method_state_display notes=audit.method_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_method_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_method_notes %}
-                            {% include 'audits/helpers/retest_statement_field_info.html' with name='Access Requirements' example='audits/statement_examples/access_requirements_state.html' decision=audit.get_access_requirements_state_display notes=audit.access_requirements_notes %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_access_requirements_state %}
-                            {% include 'common/amp_field.html' with field=form.audit_retest_access_requirements_notes %}
                             {% include 'common/amp_field.html' with field=form.audit_retest_statement_2_complete_date %}
                         </div>
                         <div class="govuk-grid-column-full govuk-button-group">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_1.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_1.html
@@ -38,36 +38,42 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=0 %}
+                    {% if not audit.no_accessibility_statement_found %}
+                        {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=0 %}
+                    {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% include 'common/amp_field_link_button.html' with field=form.accessibility_statement_backup_url %}
-                            {% if audit.accessibility_statement_backup_url_date %}
-                                <p class="govuk-body amp-margin-top-minus-20"> Added {{ audit.accessibility_statement_backup_url_date }} </p>
+                            {% if audit.no_accessibility_statement_found %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
+                            {% else %}
+                                {% include 'common/amp_field_link_button.html' with field=form.accessibility_statement_backup_url %}
+                                {% if audit.accessibility_statement_backup_url_date %}
+                                    <p class="govuk-body amp-margin-top-minus-20"> Added {{ audit.accessibility_statement_backup_url_date }} </p>
+                                {% endif %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.scope_state help_details='audits/statement_examples/scope_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.scope_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.feedback_state help_details='audits/statement_examples/feedback_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.feedback_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.contact_information_state  help_details='audits/statement_examples/contact_information_state.html'%}
+                                <details class="govuk-details" data-module="govuk-details">
+                                    <summary class="govuk-details__summary">
+                                        <span class="govuk-details__summary-text">Add contact</span>
+                                    </summary>
+                                    <div class="govuk-details__text">
+                                        {% include 'common/amp_field.html' with field=form.add_contact_email %}
+                                        {% include 'common/amp_field.html' with field=form.add_contact_notes %}
+                                    </div>
+                                </details>
+                                {% include 'common/amp_field.html' with field=form.contact_information_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.enforcement_procedure_state help_details='audits/statement_examples/enforcement_procedure_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.enforcement_procedure_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.declaration_state help_details='audits/statement_examples/declaration_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.declaration_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.compliance_state help_details='audits/statement_examples/compliance_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.compliance_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.non_regulation_state help_details='audits/statement_examples/non_regulation_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.non_regulation_notes %}
                             {% endif %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.scope_state help_details='audits/statement_examples/scope_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.scope_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.feedback_state help_details='audits/statement_examples/feedback_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.feedback_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.contact_information_state  help_details='audits/statement_examples/contact_information_state.html'%}
-                            <details class="govuk-details" data-module="govuk-details">
-                                <summary class="govuk-details__summary">
-                                    <span class="govuk-details__summary-text">Add contact</span>
-                                </summary>
-                                <div class="govuk-details__text">
-                                    {% include 'common/amp_field.html' with field=form.add_contact_email %}
-                                    {% include 'common/amp_field.html' with field=form.add_contact_notes %}
-                                </div>
-                            </details>
-                            {% include 'common/amp_field.html' with field=form.contact_information_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.enforcement_procedure_state help_details='audits/statement_examples/enforcement_procedure_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.enforcement_procedure_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.declaration_state help_details='audits/statement_examples/declaration_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.declaration_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.compliance_state help_details='audits/statement_examples/compliance_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.compliance_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.non_regulation_state help_details='audits/statement_examples/non_regulation_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.non_regulation_notes %}
                             {% include 'common/amp_field.html' with field=form.audit_statement_1_complete_date %}
                         </div>
                         <div class="govuk-grid-column-full govuk-button-group">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_1.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_1.html
@@ -38,14 +38,12 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% if not audit.no_accessibility_statement_found %}
+                    {% if audit.accessibility_statement_found %}
                         {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=0 %}
                     {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% if audit.no_accessibility_statement_found %}
-                                {% include 'audits/helpers/no_statement_warning.html' %}
-                            {% else %}
+                            {% if audit.accessibility_statement_found %}
                                 {% include 'common/amp_field_link_button.html' with field=form.accessibility_statement_backup_url %}
                                 {% if audit.accessibility_statement_backup_url_date %}
                                     <p class="govuk-body amp-margin-top-minus-20"> Added {{ audit.accessibility_statement_backup_url_date }} </p>
@@ -73,6 +71,8 @@
                                 {% include 'common/amp_field.html' with field=form.compliance_notes %}
                                 {% include 'audits/helpers/test_statement_field_info.html' with field=form.non_regulation_state help_details='audits/statement_examples/non_regulation_state.html' %}
                                 {% include 'common/amp_field.html' with field=form.non_regulation_notes %}
+                            {% else %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
                             {% endif %}
                             {% include 'common/amp_field.html' with field=form.audit_statement_1_complete_date %}
                         </div>

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_2.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_2.html
@@ -38,25 +38,31 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% include 'audits/helpers/accessibility_statement_link.html'  with twelve_week_test=0 %}
+                    {% if not audit.no_accessibility_statement_found %}
+                        {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=0 %}
+                    {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% include 'common/amp_field_link_button.html' with field=form.accessibility_statement_backup_url %}
-                            {% if audit.accessibility_statement_backup_url_date %}
-                                <p class="govuk-body amp-margin-top-minus-20"> Added {{audit.accessibility_statement_backup_url_date}} </p>
+                            {% if audit.no_accessibility_statement_found %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
+                            {% else %}
+                                {% include 'common/amp_field_link_button.html' with field=form.accessibility_statement_backup_url %}
+                                {% if audit.accessibility_statement_backup_url_date %}
+                                    <p class="govuk-body amp-margin-top-minus-20"> Added {{audit.accessibility_statement_backup_url_date}} </p>
+                                {% endif %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.disproportionate_burden_state help_details='audits/statement_examples/disproportionate_burden_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.disproportionate_burden_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.content_not_in_scope_state help_details='audits/statement_examples/content_not_in_scope_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.content_not_in_scope_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.preparation_date_state help_details='audits/statement_examples/preparation_date_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.preparation_date_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.review_state help_details='audits/statement_examples/review_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.review_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.method_state help_details='audits/statement_examples/method_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.method_notes %}
+                                {% include 'audits/helpers/test_statement_field_info.html' with field=form.access_requirements_state help_details='audits/statement_examples/access_requirements_state.html' %}
+                                {% include 'common/amp_field.html' with field=form.access_requirements_notes %}
                             {% endif %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.disproportionate_burden_state help_details='audits/statement_examples/disproportionate_burden_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.disproportionate_burden_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.content_not_in_scope_state help_details='audits/statement_examples/content_not_in_scope_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.content_not_in_scope_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.preparation_date_state help_details='audits/statement_examples/preparation_date_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.preparation_date_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.review_state help_details='audits/statement_examples/review_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.review_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.method_state help_details='audits/statement_examples/method_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.method_notes %}
-                            {% include 'audits/helpers/test_statement_field_info.html' with field=form.access_requirements_state help_details='audits/statement_examples/access_requirements_state.html' %}
-                            {% include 'common/amp_field.html' with field=form.access_requirements_notes %}
                             {% include 'common/amp_field.html' with field=form.audit_statement_2_complete_date %}
                         </div>
                         <div class="govuk-grid-column-full govuk-button-group">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_2.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_2.html
@@ -38,14 +38,12 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    {% if not audit.no_accessibility_statement_found %}
+                    {% if audit.accessibility_statement_found %}
                         {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=0 %}
                     {% endif %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
-                            {% if audit.no_accessibility_statement_found %}
-                                {% include 'audits/helpers/no_statement_warning.html' %}
-                            {% else %}
+                            {% if audit.accessibility_statement_found %}
                                 {% include 'common/amp_field_link_button.html' with field=form.accessibility_statement_backup_url %}
                                 {% if audit.accessibility_statement_backup_url_date %}
                                     <p class="govuk-body amp-margin-top-minus-20"> Added {{audit.accessibility_statement_backup_url_date}} </p>
@@ -62,6 +60,8 @@
                                 {% include 'common/amp_field.html' with field=form.method_notes %}
                                 {% include 'audits/helpers/test_statement_field_info.html' with field=form.access_requirements_state help_details='audits/statement_examples/access_requirements_state.html' %}
                                 {% include 'common/amp_field.html' with field=form.access_requirements_notes %}
+                            {% else %}
+                                {% include 'audits/helpers/no_statement_warning.html' %}
                             {% endif %}
                             {% include 'common/amp_field.html' with field=form.audit_statement_2_complete_date %}
                         </div>

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/accessibility_statement_link.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/accessibility_statement_link.html
@@ -1,16 +1,9 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
         <div class="govuk-body">
-            {% if audit.accessibility_statement_page.url and audit.accessibility_statement_page.not_found != 'yes' %}
-                <a href="{{ audit.accessibility_statement_page.url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                    Link to {{ audit.accessibility_statement_page|lower }}
-                </a>
-            {% else %}
-                No accessibility statement found. Add page in
-                <a href="{% url 'audits:edit-audit-pages' audit.id %}" class="govuk-link govuk-link--no-visited-state">
-                    pages
-                </a>
-            {% endif %}
+            <a href="{{ audit.accessibility_statement_page.url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
+                Link to {{ audit.accessibility_statement_page|lower }}
+            </a>
             {% if audit.accessibility_statement_backup_url and twelve_week_test %}
                 <br>
                 <a href="{{ audit.accessibility_statement_backup_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/no_statement_warning.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/no_statement_warning.html
@@ -1,0 +1,12 @@
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        The statement assessment is not visible as no statement has been found
+        for this organisation website. To make the form visible, add an
+        accessibility statement to
+        <a href="{% url 'audits:edit-audit-pages' audit.id %}" class="govuk-link govuk-link--no-visited-state">
+            Test > Pages</a>
+        and uncheck 'Not found?'
+    </strong>
+</div>

--- a/accessibility_monitoring_platform/apps/audits/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_models.py
@@ -250,29 +250,29 @@ def test_wcag_definition_strings():
 
 
 @pytest.mark.django_db
-def test_no_accessibility_statement_found():
+def test_accessibility_statement_found():
     """
-    Test all the ways an accessibility statement may not be found.
+    Test that an accessibility statement was found.
     """
     case: Case = Case.objects.create()
     audit: Audit = Audit.objects.create(case=case)
 
     # No page
-    assert audit.no_accessibility_statement_found is True
+    assert audit.accessibility_statement_found is False
 
     page: Page = Page.objects.create(audit=audit, page_type=PAGE_TYPE_STATEMENT)
 
     # No URL
-    assert audit.no_accessibility_statement_found is True
+    assert audit.accessibility_statement_found is False
 
     page.url = "https://example.com"
     page.save()
 
     # Not found flag not set
-    assert audit.no_accessibility_statement_found is False
+    assert audit.accessibility_statement_found is True
 
     page.not_found = BOOLEAN_TRUE
     page.save()
 
     # Not found flag set
-    assert audit.no_accessibility_statement_found is True
+    assert audit.accessibility_statement_found is False

--- a/accessibility_monitoring_platform/apps/audits/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_models.py
@@ -7,6 +7,7 @@ from typing import List
 from django.db.models.query import QuerySet
 
 from ...cases.models import Case
+from ...common.models import BOOLEAN_TRUE
 from ..models import (
     Audit,
     Page,
@@ -232,7 +233,7 @@ def test_check_result_returns_id_and_fields_for_retest():
 
 def test_wcag_definition_strings():
     """
-    Test WCAg definitions return expected string values.
+    Test WCAG definitions return expected string values.
     """
     wcag_definition: WcagDefinition = WcagDefinition(
         type=TEST_TYPE_PDF, name=WCAG_TYPE_PDF_NAME
@@ -246,3 +247,32 @@ def test_wcag_definition_strings():
         str(wcag_definition_with_description)
         == f"{WCAG_TYPE_PDF_NAME}: {WCAG_DESCRIPTION} (PDF)"
     )
+
+
+@pytest.mark.django_db
+def test_no_accessibility_statement_found():
+    """
+    Test all the ways an accessibility statement may not be found.
+    """
+    case: Case = Case.objects.create()
+    audit: Audit = Audit.objects.create(case=case)
+
+    # No page
+    assert audit.no_accessibility_statement_found is True
+
+    page: Page = Page.objects.create(audit=audit, page_type=PAGE_TYPE_STATEMENT)
+
+    # No URL
+    assert audit.no_accessibility_statement_found is True
+
+    page.url = "https://example.com"
+    page.save()
+
+    # Not found flag not set
+    assert audit.no_accessibility_statement_found is False
+
+    page.not_found = BOOLEAN_TRUE
+    page.save()
+
+    # Not found flag set
+    assert audit.no_accessibility_statement_found is True

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -17,6 +17,7 @@ from accessibility_monitoring_platform.apps.common.models import BOOLEAN_TRUE
 from ...cases.models import Case, Contact, REPORT_METHODOLOGY_ODT
 from ..models import (
     PAGE_TYPE_PDF,
+    PAGE_TYPE_STATEMENT,
     Audit,
     CheckResult,
     Page,
@@ -740,12 +741,35 @@ def test_statement_update_one_shows_statement_link(admin_client):
 @pytest.mark.parametrize(
     "url_name, field_label",
     [
-        ("audits:audit-detail", "Non-accessible Content - non compliance with regulations"),
-        ("audits:edit-audit-statement-1", "Non-accessible Content - non compliance with regulations"),
-        ("audits:edit-audit-statement-2", "Non-accessible Content - disproportionate burden"),
+        (
+            "audits:audit-detail",
+            "Non-accessible Content - non compliance with regulations",
+        ),
+        (
+            "audits:edit-audit-statement-1",
+            "Non-accessible Content - non compliance with regulations",
+        ),
+        (
+            "audits:edit-audit-statement-2",
+            "Non-accessible Content - disproportionate burden",
+        ),
+        (
+            "audits:audit-retest-detail",
+            "Retest non-accessible content - non compliance with regulations state",
+        ),
+        (
+            "audits:edit-audit-retest-statement-1",
+            "Non-accessible Content - non compliance with regulations",
+        ),
+        (
+            "audits:edit-audit-retest-statement-2",
+            "Non-accessible Content - disproportionate burden",
+        ),
     ],
 )
-def test_statement_details_hidden_when_no_statement_page(url_name, field_label, admin_client):
+def test_statement_details_hidden_when_no_statement_page(
+    url_name, field_label, admin_client
+):
     """
     Test that accessibility statement details and form fields shown only if
     such a page is present.
@@ -1158,6 +1182,9 @@ def test_all_initial_statement_one_notes_included_on_retest(admin_client):
     audit.compliance_notes = "Initial compliance notes"
     audit.non_regulation_notes = "Initial non-regulation notes"
     audit.save()
+    Page.objects.create(
+        audit=audit, page_type=PAGE_TYPE_STATEMENT, url=ACCESSIBILITY_STATEMENT_URL
+    )
 
     audit_pk: int = audit.id  # type: ignore
     path_kwargs: Dict[str, int] = {"pk": audit_pk}
@@ -1188,6 +1215,9 @@ def test_all_initial_statement_two_notes_included_on_retest(admin_client):
     audit.method_notes = "Initial method notes"
     audit.access_requirements_notes = "Initial access requirements notes"
     audit.save()
+    Page.objects.create(
+        audit=audit, page_type=PAGE_TYPE_STATEMENT, url=ACCESSIBILITY_STATEMENT_URL
+    )
 
     audit_pk: int = audit.id  # type: ignore
     path_kwargs: Dict[str, int] = {"pk": audit_pk}

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -52,6 +52,15 @@ WCAG_DEFINITION_NAME: str = "WCAG definiton name"
 WCAG_DEFINITION_URL: str = "https://example.com"
 PAGE_RETEST_NOTES: str = "Retest notes"
 ACCESSIBILITY_STATEMENT_URL: str = "https://example.com/accessibility-statement"
+NO_ACCESSIBILITY_STATEMENT_WARNING: str = """<strong class="govuk-warning-text__text">
+    <span class="govuk-warning-text__assistive">Warning</span>
+    The statement assessment is not visible as no statement has been found
+    for this organisation website. To make the form visible, add an
+    accessibility statement to
+    <a href="/audits/1/edit-audit-pages/" class="govuk-link govuk-link--no-visited-state">
+        Test > Pages</a>
+    and uncheck 'Not found?'
+</strong>"""
 
 
 def create_audit() -> Audit:
@@ -692,7 +701,7 @@ def test_website_decision_saved_on_case(admin_client):
 
 
 def test_statement_update_one_shows_statement_link(admin_client):
-    """Test that a accessibility statement links shown if present"""
+    """Test that an accessibility statement links shown if present"""
     audit: Audit = create_audit_and_pages()
     audit_pk: Dict[str, int] = {"pk": audit.id}  # type: ignore
 
@@ -702,7 +711,6 @@ def test_statement_update_one_shows_statement_link(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "No accessibility statement found. Add page in")
     assertNotContains(response, ACCESSIBILITY_STATEMENT_URL)
 
     page: Page = audit.accessibility_statement_page
@@ -715,7 +723,6 @@ def test_statement_update_one_shows_statement_link(admin_client):
 
     assert response.status_code == 200
 
-    assertNotContains(response, "No accessibility statement found. Add page in")
     assertContains(response, ACCESSIBILITY_STATEMENT_URL)
 
     page.not_found = BOOLEAN_TRUE
@@ -727,8 +734,58 @@ def test_statement_update_one_shows_statement_link(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "No accessibility statement found. Add page in")
     assertNotContains(response, ACCESSIBILITY_STATEMENT_URL)
+
+
+@pytest.mark.parametrize(
+    "url_name, field_label",
+    [
+        ("audits:audit-detail", "Non-accessible Content - non compliance with regulations"),
+        ("audits:edit-audit-statement-1", "Non-accessible Content - non compliance with regulations"),
+        ("audits:edit-audit-statement-2", "Non-accessible Content - disproportionate burden"),
+    ],
+)
+def test_statement_details_hidden_when_no_statement_page(url_name, field_label, admin_client):
+    """
+    Test that accessibility statement details and form fields shown only if
+    such a page is present.
+    """
+    audit: Audit = create_audit_and_pages()
+    audit_pk: Dict[str, int] = {"pk": audit.id}  # type: ignore
+
+    response: HttpResponse = admin_client.get(
+        reverse(url_name, kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, NO_ACCESSIBILITY_STATEMENT_WARNING, html=True)
+    assertNotContains(response, field_label)
+
+    page: Page = audit.accessibility_statement_page
+    page.url = ACCESSIBILITY_STATEMENT_URL
+    page.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse(url_name, kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertNotContains(response, NO_ACCESSIBILITY_STATEMENT_WARNING, html=True)
+    assertContains(response, field_label)
+
+    page.not_found = BOOLEAN_TRUE
+    page.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse(url_name, kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, NO_ACCESSIBILITY_STATEMENT_WARNING, html=True)
+    assertNotContains(response, field_label)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Trello card [#1021](https://trello.com/c/nNSjSgB3/1021-hide-statement-assessment-form-if-statement-doesnt-exist-design-attached).