### PR TITLE
1034: Patch test to use a mock time.

### DIFF
--- a/accessibility_monitoring_platform/apps/common/chart.py
+++ b/accessibility_monitoring_platform/apps/common/chart.py
@@ -206,8 +206,19 @@ def build_yearly_metric_chart(
                     line_y=LINE_LABEL_STROKE_Y,
                 )
             )
-        penultimate_datapoints: List[TimeseriesDatapoint] = timeseries.datapoints[:-1]
-        last_month_datapoints: List[TimeseriesDatapoint] = timeseries.datapoints[-2:]
+        if (
+            timeseries.datapoints
+            and timeseries.datapoints[-1].datetime.month == now.month
+        ):
+            penultimate_datapoints: List[TimeseriesDatapoint] = timeseries.datapoints[
+                :-1
+            ]
+            last_month_datapoints: List[TimeseriesDatapoint] = timeseries.datapoints[
+                -2:
+            ]
+        else:
+            penultimate_datapoints: List[TimeseriesDatapoint] = timeseries.datapoints
+            last_month_datapoints: List[TimeseriesDatapoint] = []
         polylines.append(
             Polyline(
                 stroke=stroke,

--- a/accessibility_monitoring_platform/apps/common/tests/test_chart.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_chart.py
@@ -510,6 +510,165 @@ def test_build_yearly_metric_chart(mock_timezone):
     )
 
 
+@patch("accessibility_monitoring_platform.apps.common.chart.timezone")
+def test_build_yearly_metric_chart_no_current_month_data(mock_timezone):
+    """
+    Test building of yearly metric data for line chart with no data for current month
+    """
+    mock_timezone.now.return_value = datetime(2022, 11, 10)
+    timeseries: Timeseries = Timeseries(
+        label="Counts",
+        datapoints=[
+            TimeseriesDatapoint(datetime=datetime(2022, 9, 1), value=52),
+            TimeseriesDatapoint(datetime=datetime(2022, 10, 1), value=54),
+        ],
+    )
+
+    assert build_yearly_metric_chart(lines=[timeseries]) == LineChart(
+        key=[
+            LineLabel(
+                label="Counts",
+                line_stroke="#1d70b8",
+                label_x=30,
+                label_y=-10,
+                line_x1=0,
+                line_x2=20,
+                line_y=-15,
+            )
+        ],
+        polylines=[
+            Polyline(
+                points=[
+                    Point(x_position=500, y_position=120),
+                    Point(x_position=550, y_position=115),
+                ],
+                stroke="#1d70b8",
+                stroke_dasharray="",
+            ),
+            Polyline(points=[], stroke="#1d70b8", stroke_dasharray="5"),
+        ],
+        x_axis=[
+            ChartAxisTick(
+                value=datetime(2021, 11, 1, 0, 0, tzinfo=timezone.utc),
+                label="Nov",
+                x_position=0,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 12, 1, 0, 0, tzinfo=timezone.utc),
+                label="Dec",
+                x_position=50,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 1, 1, 0, 0, tzinfo=timezone.utc),
+                label="Jan",
+                x_position=100,
+                y_position=275,
+                label_line_2="2021",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 2, 1, 0, 0, tzinfo=timezone.utc),
+                label="Feb",
+                x_position=150,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 3, 1, 0, 0, tzinfo=timezone.utc),
+                label="Mar",
+                x_position=200,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 4, 1, 0, 0, tzinfo=timezone.utc),
+                label="Apr",
+                x_position=250,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 5, 1, 0, 0, tzinfo=timezone.utc),
+                label="May",
+                x_position=300,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 6, 1, 0, 0, tzinfo=timezone.utc),
+                label="Jun",
+                x_position=350,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 7, 1, 0, 0, tzinfo=timezone.utc),
+                label="Jul",
+                x_position=400,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 8, 1, 0, 0, tzinfo=timezone.utc),
+                label="Aug",
+                x_position=450,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 9, 1, 0, 0, tzinfo=timezone.utc),
+                label="Sep",
+                x_position=500,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 10, 1, 0, 0, tzinfo=timezone.utc),
+                label="Oct",
+                x_position=550,
+                y_position=275,
+                label_line_2="",
+            ),
+            ChartAxisTick(
+                value=datetime(2021, 11, 1, 0, 0, tzinfo=timezone.utc),
+                label="Nov",
+                x_position=600,
+                y_position=275,
+                label_line_2="",
+            ),
+        ],
+        y_axis=[
+            ChartAxisTick(
+                value=100, label="100", x_position=0, y_position=0, label_line_2=""
+            ),
+            ChartAxisTick(
+                value=80, label="80", x_position=0, y_position=50, label_line_2=""
+            ),
+            ChartAxisTick(
+                value=60, label="60", x_position=0, y_position=100, label_line_2=""
+            ),
+            ChartAxisTick(
+                value=40, label="40", x_position=0, y_position=150, label_line_2=""
+            ),
+            ChartAxisTick(
+                value=20, label="20", x_position=0, y_position=200, label_line_2=""
+            ),
+            ChartAxisTick(
+                value=0, label="0", x_position=0, y_position=250, label_line_2=""
+            ),
+        ],
+        graph_height=250,
+        graph_width=600,
+        chart_height=300,
+        chart_width=750,
+        x_axis_tick_y2=260,
+        y_axis_tick_x1=-10,
+    )
+
+
 @pytest.mark.parametrize(
     "index, expected_result",
     [

--- a/accessibility_monitoring_platform/apps/common/tests/test_chart.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_chart.py
@@ -323,10 +323,12 @@ def test_get_y_axis(max_value, expected_result):
     assert get_y_axis(max_value=max_value) == expected_result
 
 
-def test_build_yearly_metric_chart():
+@patch("accessibility_monitoring_platform.apps.common.chart.timezone")
+def test_build_yearly_metric_chart(mock_timezone):
     """
     Test building of yearly metric data for line chart
     """
+    mock_timezone.now.return_value = datetime(2022, 11, 10)
     timeseries: Timeseries = Timeseries(
         label="Counts",
         datapoints=[


### PR DESCRIPTION
One of the tests was using the current time by mistake. That test failed today when the month changed from November to December.

Trello card [#1034](https://trello.com/c/nMAtrj0t/1034-add-report-metrics).