### PR TITLE
1039: Filter cases by members of new Historic auditor user group.

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -107,7 +107,7 @@ class CaseSearchForm(AMPDateRangeForm):
         super().__init__(*args, **kwargs)
 
         auditor_choices: List[Tuple[str, str]] = get_search_user_choices(
-            User.objects.filter(groups__name="Auditor")
+            User.objects.filter(groups__name="Historic auditor")
         )
         self.fields["auditor"].choices = auditor_choices  # type: ignore
         self.fields["reviewer"].choices = auditor_choices  # type: ignore


### PR DESCRIPTION
Trello card [#1039](https://trello.com/c/kKtKx9lD/1039-how-to-manage-taking-jess-or-any-other-auditors-off-the-system).