### PR TITLE
1043: Use GDS Transport font inside of SVG charts.

### DIFF
--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -754,3 +754,7 @@ img, .amp-max-width-100 {
 .amp-orange {
     color: Orange;
 }
+
+svg {
+    font-family: "GDS Transport",arial,sans-serif;
+}


### PR DESCRIPTION
Trello card [#1043](https://trello.com/c/FlHtZ48p/1043-use-gds-transport-font-inside-svg-charts).