### PR TITLE
1057: Stop HTML from being executed in previews.

### DIFF
--- a/common/static/js/markdown_preview.js
+++ b/common/static/js/markdown_preview.js
@@ -13,7 +13,7 @@ const converter = new showdown.Converter()
 function previewMarkdown (sourceId, targetId) {
   const markdown = document.getElementById(sourceId).value
   const targetElement = document.getElementById(targetId)
-  targetElement.innerHTML = converter.makeHtml(markdown)
+  targetElement.innerHTML = converter.makeHtml(markdown.replaceAll('<', '&lt;').replaceAll('`&lt;', '`<'))
 }
 
 const previewElements = document.getElementsByClassName('amp-preview')


### PR DESCRIPTION
Trello card [#1057](https://trello.com/c/fJ05rPTT/1057-allow-non-backtick-delimited-html-in-preview).