### PR TITLE
1068: Show link to test results only when URL is present.

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/testing_details.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/testing_details.html
@@ -43,8 +43,12 @@
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header amp-width-one-half">Link to test results</th>
             <td class="govuk-table__cell amp-width-one-half">
-                <a href="{{ case.test_results_url }}" class="govuk-link">Monitor document</a>
-            </td>
+                {% if case.test_results_url %}
+                    <a href="{{ case.test_results_url }}" class="govuk-link">Monitor document</a>
+                {% else %}
+                    None
+                {% endif %}
+                </td>
         </tr>
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__header amp-width-one-half">Test status</th>

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -2962,3 +2962,27 @@ def test_navigation_links_hidden_when_spreadsheet_testing(
         f"""<a href="{nav_link_url}" class="govuk-link govuk-link--no-visited-state">{nav_link_label}</a>""",
         html=True,
     )
+
+
+def test_case_details_hides_link_to_test_results_when_not_present(admin_client):
+    """
+    Test case details hides link to test results when URL not present
+    when testing methodology is spreadsheet.
+    """
+    case: Case = Case.objects.create(
+        testing_methodology=TESTING_METHODOLOGY_SPREADSHEET
+    )
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:case-detail", kwargs={"pk": case.id}),  # type: ignore
+    )
+    assert response.status_code == 200
+
+    assertContains(
+        response,
+        """<tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header amp-width-one-half">Link to test results</th>
+            <td class="govuk-table__cell amp-width-one-half">None</td>
+        </tr>""",
+        html=True,
+    )


### PR DESCRIPTION
Trello card [#1068](https://trello.com/c/C4V0u1ux/1068-missing-link-to-spreadsheet-test-results).