### PR TITLE
1071: Hide link to 12-week retest when spreadsheet.

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/nav_contents.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/nav_contents.html
@@ -29,7 +29,6 @@
             {% include './nav_content.html' with id='contact-details' name='Contact details' complete=case.contact_details_complete_date %}
             {% include './nav_content.html' with id='report-correspondence' name='Report correspondence' complete=case.report_correspondence_complete_date %}
             {% include './nav_content.html' with id='twelve-week-correspondence' name='12-week correspondence' complete=case.twelve_week_correspondence_complete_date %}
-            {% include './nav_content.html' with id='twelve-week-retest' name='12-week retest' complete=case.twelve_week_retest_complete_date %}
             {% include './nav_content.html' with id='review-changes' name='Reviewing changes' complete=case.review_changes_complete_date %}
             {% include './nav_content.html' with id='final-website' name='Final website compliance decision' complete=case.final_website_complete_date %}
             {% include './nav_content.html' with id='final-statement' name='Final accessibility statement compliance decision' complete=case.final_statement_complete_date %}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1290,11 +1290,6 @@ def test_section_complete_check_displayed_in_platform_testing_methodology(
             "twelve-week-correspondence",
         ),
         (
-            "twelve_week_retest_complete_date",
-            "12-week retest",
-            "twelve-week-retest",
-        ),
-        (
             "review_changes_complete_date",
             "Reviewing changes",
             "review-changes",
@@ -2984,5 +2979,42 @@ def test_case_details_hides_link_to_test_results_when_not_present(admin_client):
             <th scope="row" class="govuk-table__header amp-width-one-half">Link to test results</th>
             <td class="govuk-table__cell amp-width-one-half">None</td>
         </tr>""",
+        html=True,
+    )
+
+
+def test_case_details_contents_hides_link_to_12_week_retest_when_testing_methodology_spreadsheet(
+    admin_client,
+):
+    """
+    Test case details hides contents link to 12-week retest
+    when testing methodology is spreadsheet.
+    """
+    case: Case = Case.objects.create()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:case-detail", kwargs={"pk": case.id}),  # type: ignore
+    )
+    assert response.status_code == 200
+
+    assertContains(
+        response,
+        """<a href="#twelve-week-retest" class="govuk-link govuk-link--no-visited-state">
+            12-week retest</a>""",
+        html=True,
+    )
+
+    case.testing_methodology = TESTING_METHODOLOGY_SPREADSHEET
+    case.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:case-detail", kwargs={"pk": case.id}),  # type: ignore
+    )
+    assert response.status_code == 200
+
+    assertNotContains(
+        response,
+        """<a href="#twelve-week-retest" class="govuk-link govuk-link--no-visited-state">
+            12-week retest</a>""",
         html=True,
     )


### PR DESCRIPTION
Trello card [#1071](https://trello.com/c/zK3oB7Mi/1071-spreadsheet-testing-case-showing-platform-ui-in-contents).