### PR TITLE
1078: Fix codeblocks in showdownjs markdown previews.

### DIFF
--- a/common/static/js/markdown_preview.js
+++ b/common/static/js/markdown_preview.js
@@ -8,7 +8,7 @@ markdown to be previewed.
 
 const showdown = require('showdown')
 showdown.setFlavor('original')
-const converter = new showdown.Converter()
+const converter = new showdown.Converter({ ghCodeBlocks: true })
 
 function previewMarkdown (sourceId, targetId) {
   const markdown = document.getElementById(sourceId).value


### PR DESCRIPTION
Trello card [#1078](https://trello.com/c/0fT5gtLg/1078-code-blocks-wrong-in-previews).