### PR TITLE
1116: Label errors as error when there is only one

### DIFF
--- a/__tests__/audits_check_filter.spec.js
+++ b/__tests__/audits_check_filter.spec.js
@@ -68,4 +68,11 @@ describe('test updateCheckListFiltering', () => {
     updateCheckListFiltering()
     expect(document.getElementById('number_of_errors').innerHTML).toEqual('Showing 3 errors')
   })
+
+  test('check single error', () => {
+    document.getElementById('id_name').value = 'contrast'
+    document.getElementById('id_type_filter_2').checked = true
+    updateCheckListFiltering()
+    expect(document.getElementById('number_of_errors').innerHTML).toEqual('Showing 1 error')
+  })
 })

--- a/common/static/js/audits_check_filter.js
+++ b/common/static/js/audits_check_filter.js
@@ -53,7 +53,8 @@ function updateCheckListFiltering (event) {
       numberChecksDisplayed += 1
     }
 
-    document.getElementById('number_of_errors').innerHTML = `Showing ${numberChecksDisplayed} errors`
+    const errorSuffix = numberChecksDisplayed === 1 ? 'error' : 'errors'
+    document.getElementById('number_of_errors').innerHTML = `Showing ${numberChecksDisplayed} ${errorSuffix}`
   })
 }
 


### PR DESCRIPTION
Trello card [#1116](https://trello.com/c/57xHlXef/1116-change-errors-to-error-on-testing-pages-when-there-is-one-error).