### PR TITLE
1137: Hide links to report files when platform reporting used

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1710,7 +1710,10 @@ def test_case_details_includes_link_to_report(admin_client):
     Test that the case details page contains a link to the report
     """
     report_final_pdf_url: str = "https://report-final-pdf-url.com"
-    case: Case = Case.objects.create(report_final_pdf_url=report_final_pdf_url)
+    case: Case = Case.objects.create(
+        report_methodology=REPORT_METHODOLOGY_ODT,
+        report_final_pdf_url=report_final_pdf_url,
+    )
 
     response: HttpResponse = admin_client.get(
         reverse("cases:case-detail", kwargs={"pk": case.id}),
@@ -1734,7 +1737,7 @@ def test_case_details_includes_no_link_to_report(admin_client):
     """
     Test that the case details page contains no link to the report if none is set
     """
-    case: Case = Case.objects.create()
+    case: Case = Case.objects.create(report_methodology=REPORT_METHODOLOGY_ODT)
 
     response: HttpResponse = admin_client.get(
         reverse("cases:case-detail", kwargs={"pk": case.id}),

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -169,8 +169,15 @@ class CaseDetailView(DetailView):
             extract_form_labels_and_values, instance=self.object
         )
 
+        excluded_fields: List[str] = (
+            ["report_final_odt_url", "report_final_pdf_url"]
+            if self.object.report_methodology == REPORT_METHODOLOGY_PLATFORM
+            else []
+        )
+
         qa_process_rows: List[FieldLabelAndValue] = get_rows(
-            form=CaseQAProcessUpdateForm()
+            form=CaseQAProcessUpdateForm(),
+            excluded_fields=excluded_fields,
         )
 
         if self.object.report_methodology == REPORT_METHODOLOGY_PLATFORM:

--- a/accessibility_monitoring_platform/apps/common/form_extract_utils.py
+++ b/accessibility_monitoring_platform/apps/common/form_extract_utils.py
@@ -5,6 +5,7 @@ from typing import (
     Any,
     ClassVar,
     List,
+    Optional,
     Type,
     Union,
 )
@@ -70,11 +71,16 @@ class FieldLabelAndValue:
 def extract_form_labels_and_values(  # noqa: C901
     instance: models.Model,
     form: Type[forms.Form],
+    excluded_fields: Optional[List[str]] = None,
 ) -> List[FieldLabelAndValue]:
     """Extract field labels from form and values from case for use in html rows"""
     display_rows: List[FieldLabelAndValue] = []
+    if excluded_fields is None:
+        excluded_fields = []
     for field_name, field in form.fields.items():
         if field_name in EXCLUDED_FIELDS:
+            continue
+        if field_name in excluded_fields:
             continue
         type_of_value: str = FieldLabelAndValue.TEXT_TYPE
         value: Any = getattr(instance, field_name)

--- a/accessibility_monitoring_platform/apps/common/tests/test_form_extract_utils.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_form_extract_utils.py
@@ -104,7 +104,8 @@ def test_extract_form_labels_and_values():
 
 def test_extract_form_labels_and_values_with_no_values_set():
     """
-    Test extraction of labels from form and values from case when there are no values populated.
+    Test extraction of labels from form and values from case when
+    there are no values populated.
     """
     case: Case = Case()
 
@@ -128,4 +129,27 @@ def test_extract_form_labels_and_values_with_no_values_set():
     assert labels_and_values[4] == FieldLabelAndValue(
         label=REPORT_SENT_ON_LABEL,
         value=None,
+    )
+
+
+def test_extract_form_labels_and_values_can_exclude_fields():
+    """
+    Test fields can be excluded from extraction of labels from form and values
+    from case.
+    """
+    case: Case = Case()
+
+    labels_and_values: List[FieldLabelAndValue] = extract_form_labels_and_values(
+        instance=case,
+        form=CaseForm(),
+        excluded_fields=["home_page_url", "report_sent_date"],
+    )
+
+    assert len(labels_and_values) == 3
+    assert labels_and_values[0] == FieldLabelAndValue(label=AUDITOR_LABEL, value=None)
+    assert labels_and_values[1] == FieldLabelAndValue(
+        label=SECTOR_LABEL, value="Unknown"
+    )
+    assert labels_and_values[2] == FieldLabelAndValue(
+        label=TEST_TYPE_LABEL, value=case.get_test_type_display()
     )


### PR DESCRIPTION
Trello card [#1137](https://trello.com/c/Q04zBUf9/1137-remove-link-to-odt-report-and-link-to-final-pdf-report-in-case-overview).