### PR TITLE
1142: Save QA process form when Add comment button is pressed

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
@@ -68,10 +68,15 @@
                                     </span>
                                 </summary>
                                 <div class="govuk-details__text">
-                                    <p class="govuk-body-m">
-                                        <a href="{% url 'cases:add-qa-comment' case.id %}" class="govuk-button govuk-button--secondary amp-margin-bottom-0">
-                                            Add comment</a>
-                                    </p>
+                                    <div class="govuk-button-group">
+                                        <input
+                                            type="submit"
+                                            value="Add comment"
+                                            name="add_comment"
+                                            class="govuk-button govuk-button--secondary"
+                                            data-module="govuk-button"
+                                        />
+                                    </div>
                                     {% for comment in case.qa_comments %}
                                         {% include "comments/helpers/comment.html" %}
                                         {% if request.user == comment.user  %}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -822,6 +822,24 @@ def test_add_qa_comment(admin_client, admin_user):
     assert event.type == EVENT_TYPE_MODEL_CREATE
 
 
+def test_add_comment_button_redirects_to_add_comment(admin_client):
+    """Test pressing add comment button redirects to add comment"""
+    case: Case = Case.objects.create()
+
+    response: HttpResponse = admin_client.post(
+        reverse("cases:edit-qa-process", kwargs={"pk": case.id}),
+        {
+            "add_comment": "Add comment",
+            "version": case.version,
+        },
+    )
+    assert response.status_code == 302
+    assert (
+        response.url
+        == f'{reverse("cases:add-qa-comment", kwargs={"case_id": case.id})}'
+    )
+
+
 def test_add_qa_comment_redirects_to_qa_process(admin_client):
     """Test adding a QA comment redirects to QA process page"""
     case: Case = Case.objects.create()

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -457,9 +457,10 @@ class CaseQAProcessUpdateView(CaseUpdateView):
         """
         Detect the submit button used and act accordingly.
         """
+        if "add_comment" in self.request.POST:
+            return reverse("cases:add-qa-comment", kwargs={"case_id": self.object.id})
         if "save_continue" in self.request.POST:
-            case_pk: Dict[str, int] = {"pk": self.object.id}
-            return reverse("cases:edit-contact-details", kwargs=case_pk)
+            return reverse("cases:edit-contact-details", kwargs={"pk": self.object.id})
         return super().get_success_url()
 
 


### PR DESCRIPTION
Trello card [#1142](https://trello.com/c/ZjDAsNG5/1142-make-sure-add-comment-in-qa-page-saves-the-page).