### PR TITLE
1165: Add Enforcement recommendation notes to Export to feedback survey CSV

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
@@ -307,7 +307,7 @@ def test_download_feedback_survey_cases():
         column.column_name
         for column in FEEDBACK_SURVEY_COLUMNS_FOR_EXPORT + CONTACT_COLUMNS_FOR_EXPORT
     ]
-    assert csv_body == [["1", "", "16/12/2022", "", ""]]
+    assert csv_body == [["1", "", "16/12/2022", "", "", ""]]
 
 
 @pytest.mark.django_db

--- a/accessibility_monitoring_platform/apps/cases/utils.py
+++ b/accessibility_monitoring_platform/apps/cases/utils.py
@@ -409,6 +409,10 @@ FEEDBACK_SURVEY_COLUMNS_FOR_EXPORT: List[ColumnAndFieldNames] = [
     ColumnAndFieldNames(
         column_name="Closing the case date", field_name="compliance_email_sent_date"
     ),
+    ColumnAndFieldNames(
+        column_name="Enforcement recommendation notes",
+        field_name="recommendation_notes",
+    ),
 ]
 
 


### PR DESCRIPTION
Trello card [#1165](https://trello.com/c/hvL5g908/1165-add-column-to-csv).