### PR TITLE
1140: Show fields to create two extra pages if none exist

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/forms.py
+++ b/accessibility_monitoring_platform/apps/audits/forms.py
@@ -114,6 +114,9 @@ AuditExtraPageFormset: Any = forms.modelformset_factory(
 AuditExtraPageFormsetOneExtra: Any = forms.modelformset_factory(
     Page, AuditExtraPageUpdateForm, extra=1
 )
+AuditExtraPageFormsetTwoExtra: Any = forms.modelformset_factory(
+    Page, AuditExtraPageUpdateForm, extra=2
+)
 
 
 class AuditStandardPageUpdateForm(AuditExtraPageUpdateForm):

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -586,6 +586,42 @@ def test_standard_pages_appear_on_pages_page(admin_client):
     assertContains(response, """<h2 class="govuk-heading-m">A Form</h2>""", html=True)
 
 
+def test_two_extra_pages_appear_on_pages_page(admin_client):
+    """
+    Test that two extra pages appear on the pages page when no extra pages
+    have yet been created.
+    """
+    audit: Audit = create_audit_and_pages()
+
+    response: HttpResponse = admin_client.get(
+        reverse("audits:edit-audit-pages", kwargs={"pk": audit.id}),
+    )
+    assert response.status_code == 200
+    assertContains(
+        response,
+        """<h2 id="extra-page-1" class="govuk-heading-m">Page 1</h2>""",
+        html=True,
+    )
+    assertContains(
+        response,
+        """<h2 id="extra-page-2" class="govuk-heading-m">Page 2</h2>""",
+        html=True,
+    )
+
+    Page.objects.create(audit=audit, page_type=PAGE_TYPE_EXTRA)
+
+    response: HttpResponse = admin_client.get(
+        reverse("audits:edit-audit-pages", kwargs={"pk": audit.id}),
+    )
+
+    assert response.status_code == 200
+    assertNotContains(
+        response,
+        """<h2 id="extra-page-2" class="govuk-heading-m">Page 2</h2>""",
+        html=True,
+    )
+
+
 def test_add_extra_page_form_appears(admin_client):
     """
     Test that pressing the save and create additional page button adds an extra page form

--- a/accessibility_monitoring_platform/apps/audits/views.py
+++ b/accessibility_monitoring_platform/apps/audits/views.py
@@ -40,6 +40,7 @@ from .forms import (
     AuditStandardPageFormset,
     AuditExtraPageFormset,
     AuditExtraPageFormsetOneExtra,
+    AuditExtraPageFormsetTwoExtra,
     AuditPagesUpdateForm,
     AuditPageChecksForm,
     CheckResultFilterForm,
@@ -294,6 +295,7 @@ class AuditPagesUpdateView(AuditUpdateView):
     def get_context_data(self, **kwargs: Dict[str, Any]) -> Dict[str, Any]:
         """Get context data for template rendering"""
         context: Dict[str, Any] = super().get_context_data(**kwargs)
+        audit: Audit = self.object
         if self.request.POST:
             standard_pages_formset: AuditStandardPageFormset = AuditStandardPageFormset(
                 self.request.POST, prefix="standard"
@@ -303,18 +305,25 @@ class AuditPagesUpdateView(AuditUpdateView):
             )
         else:
             standard_pages_formset: AuditStandardPageFormset = AuditStandardPageFormset(
-                queryset=self.object.standard_pages, prefix="standard"
+                queryset=audit.standard_pages, prefix="standard"
             )
             if "add_extra" in self.request.GET:
                 extra_pages_formset: AuditExtraPageFormsetOneExtra = (
                     AuditExtraPageFormsetOneExtra(
-                        queryset=self.object.extra_pages, prefix="extra"
+                        queryset=audit.extra_pages, prefix="extra"
                     )
                 )
             else:
-                extra_pages_formset: AuditExtraPageFormset = AuditExtraPageFormset(
-                    queryset=self.object.extra_pages, prefix="extra"
-                )
+                if audit.extra_pages:
+                    extra_pages_formset: AuditExtraPageFormset = AuditExtraPageFormset(
+                        queryset=audit.extra_pages, prefix="extra"
+                    )
+                else:
+                    extra_pages_formset: AuditExtraPageFormset = (
+                        AuditExtraPageFormsetTwoExtra(
+                            queryset=audit.extra_pages, prefix="extra"
+                        )
+                    )
         for form in standard_pages_formset:
             if form.instance.page_type == PAGE_TYPE_FORM:
                 form.fields["is_contact_page"].label = "Form is on contact page"


### PR DESCRIPTION
Trello card [#1140](https://trello.com/c/qr6j1PFY/1140-have-two-pages-compulsory-on-the-add-pages-page-design-attached).