### PR TITLE
1155: Fix displaying numbers of visitors on Edit report page

### DIFF
--- a/accessibility_monitoring_platform/apps/reports/views.py
+++ b/accessibility_monitoring_platform/apps/reports/views.py
@@ -43,6 +43,7 @@ from .models import (
 from .utils import (
     check_for_buttons_by_name,
     generate_report_content,
+    get_report_visits_metrics,
 )
 
 
@@ -103,6 +104,12 @@ class ReportDetailView(DetailView):
     model: Type[Report] = Report
     context_object_name: str = "report"
     template_name: str = "reports/report_edit.html"
+
+    def get_context_data(self, **kwargs) -> Dict[str, Any]:
+        """Add report visits metrics context"""
+        context: Dict[str, Any] = super().get_context_data(**kwargs)
+        context.update(get_report_visits_metrics(self.object.case))
+        return context
 
 
 class ReportUpdateView(UpdateView):


### PR DESCRIPTION
Trello card [#1155](https://trello.com/c/GMFdeDht/1155-views-and-unique-visitors-is-missing-in-report-editor).