### PR TITLE
1167: Add percentages to outstanding issues page

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/outstanding_issues.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/outstanding_issues.html
@@ -70,12 +70,26 @@
                     {% else %}
                         0
                     {% endif %}
+                    {% if case.audit.failed_check_results %}
+                        ({% widthratio case.audit.fixed_check_results.count case.audit.failed_check_results.count 100 %}%)
+                    {% endif %}
                     WCAG errors have been fixed
                 </p>
                 <p class="govuk-body">
-                    {{ case.audit.fixed_accessibility_statement_checks_count }}
+                    {% if case.audit.fixed_accessibility_statement_checks_count %}
+                        {{ case.audit.fixed_accessibility_statement_checks_count }}
+                    {% else %}
+                        0
+                    {% endif %}
                     of
-                    {{ case.audit.accessibility_statement_initially_invalid_checks_count }}
+                    {% if case.audit.accessibility_statement_initially_invalid_checks_count %}
+                        {{ case.audit.accessibility_statement_initially_invalid_checks_count }}
+                    {% else %}
+                        0
+                    {% endif %}
+                    {% if case.audit.accessibility_statement_initially_invalid_checks_count %}
+                        ({% widthratio case.audit.fixed_accessibility_statement_checks_count case.audit.accessibility_statement_initially_invalid_checks_count 100 %}%)
+                    {% endif %}
                     statement errors have been fixed
                 </p>
                 {% if show_failures_by_page %}


### PR DESCRIPTION
Trello card [#1167](https://trello.com/c/pYabsO8w/1167-add-percentages-to-case-overview-page-design-attached).