### PR TITLE
1100: Move 12-week statement backup field to compliance page

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/forms.py
+++ b/accessibility_monitoring_platform/apps/audits/forms.py
@@ -883,9 +883,6 @@ class AuditRetestStatement1UpdateForm(VersionForm):
     Form for retesting accessibility statement 1 checks
     """
 
-    audit_retest_accessibility_statement_backup_url = AMPURLField(
-        label="Link to 12-week saved accessibility statement, only if not compliant",
-    )
     audit_retest_scope_state = AMPChoiceRadioField(
         label="",
         choices=SCOPE_STATE_CHOICES,
@@ -927,7 +924,6 @@ class AuditRetestStatement1UpdateForm(VersionForm):
         model = Audit
         fields: List[str] = [
             "version",
-            "audit_retest_accessibility_statement_backup_url",
             "audit_retest_scope_state",
             "audit_retest_scope_notes",
             "audit_retest_feedback_state",
@@ -951,9 +947,6 @@ class AuditRetestStatement2UpdateForm(VersionForm):
     Form for retesting accessibility statement 2 checks
     """
 
-    audit_retest_accessibility_statement_backup_url = AMPURLField(
-        label="Link to 12-week saved accessibility statement, only if not compliant",
-    )
     audit_retest_disproportionate_burden_state = AMPChoiceRadioField(
         label="",
         choices=DISPROPORTIONATE_BURDEN_STATE_CHOICES,
@@ -990,7 +983,6 @@ class AuditRetestStatement2UpdateForm(VersionForm):
         model = Audit
         fields: List[str] = [
             "version",
-            "audit_retest_accessibility_statement_backup_url",
             "audit_retest_disproportionate_burden_state",
             "audit_retest_disproportionate_burden_notes",
             "audit_retest_content_not_in_scope_state",
@@ -1012,12 +1004,16 @@ class AuditRetestStatementDecisionUpdateForm(VersionForm):
     Form for retesting statement decision
     """
 
+    audit_retest_accessibility_statement_backup_url = AMPURLField(
+        label="Link to 12-week saved accessibility statement, only if not compliant",
+    )
     audit_retest_statement_decision_complete_date = AMPDatePageCompleteField()
 
     class Meta:
         model = Audit
         fields: List[str] = [
             "version",
+            "audit_retest_accessibility_statement_backup_url",
             "audit_retest_statement_decision_complete_date",
         ]
 

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
@@ -50,12 +50,6 @@
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             {% if audit.accessibility_statement_initially_found or audit.twelve_week_accessibility_statement_found %}
-                                {% if audit.accessibility_statement_initially_found %}
-                                    {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
-                                    {% if audit.audit_retest_accessibility_statement_backup_url_date %}
-                                        <p class="govuk-body amp-margin-top-minus-20">Added {{ audit.audit_retest_accessibility_statement_backup_url_date }}</p>
-                                    {% endif %}
-                                {% endif %}
                                 {% include 'audits/helpers/retest_statement_field_info.html' with name='Scope' example='audits/statement_examples/scope_state.html' decision=audit.get_scope_state_display notes=audit.scope_notes %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_scope_state %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_scope_notes %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_2.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_2.html
@@ -50,12 +50,6 @@
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             {% if audit.accessibility_statement_initially_found or audit.twelve_week_accessibility_statement_found %}
-                                {% if audit.accessibility_statement_initially_found %}
-                                    {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
-                                    {% if audit.audit_retest_accessibility_statement_backup_url_date %}
-                                        <p class="govuk-body amp-margin-top-minus-20">Added {{ audit.audit_retest_accessibility_statement_backup_url_date }}</p>
-                                    {% endif %}
-                                {% endif %}
                                 {% include 'audits/helpers/retest_statement_field_info.html' with name='Non-accessible Content - disproportionate burden' example='audits/statement_examples/disproportionate_burden_state.html' decision=audit.get_disproportionate_burden_state_display notes=audit.disproportionate_burden_notes %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_disproportionate_burden_state %}
                                 {% include 'common/amp_field.html' with field=form.audit_retest_disproportionate_burden_notes %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_decision.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_decision.html
@@ -35,6 +35,7 @@
                 {% include 'audits/helpers/end_of_test.html' %}
                 <form method="post" action="{% url 'audits:edit-audit-retest-statement-decision' audit.id %}">
                     {% csrf_token %}
+                    {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">
                             {% if audit.twelve_week_accessibility_statement_found %}
@@ -43,8 +44,14 @@
                                 {% include 'cases/helpers/view_initial_decision.html' with case=audit.case %}
                             {% endif %}
                             {% include 'audits/helpers/accessibility_statement_link.html' with twelve_week_test=1 %}
+                            {% if audit.accessibility_statement_initially_found %}
+                                {% include 'common/amp_field_link_button.html' with field=form.audit_retest_accessibility_statement_backup_url %}
+                                {% if audit.audit_retest_accessibility_statement_backup_url_date %}
+                                    <p class="govuk-body amp-margin-top-minus-20">Added {{ audit.audit_retest_accessibility_statement_backup_url_date }}</p>
+                                {% endif %}
+                            {% endif %}
                             {% include 'common/amp_form_snippet.html' with form=case_form %}
-                            {% include 'common/amp_form_snippet.html' %}
+                            {% include 'common/amp_field.html' with field=form.audit_retest_statement_decision_complete_date %}
                         </div>
                         <div class="govuk-grid-column-full govuk-button-group">
                             <input


### PR DESCRIPTION
Trello card [#1100](https://trello.com/c/Vn95pWV8/1100-move-link-to-12-week-saved-accessibility-statement-only-if-not-compliant-field-to-statement-compliance-decision-page).