### PR TITLE
1190: Remove pages missing on retest from outstanding issues

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -762,6 +762,7 @@ class Audit(VersionModel):
                 check_result_state=CHECK_RESULT_ERROR,
                 page__is_deleted=False,
                 page__not_found=BOOLEAN_FALSE,
+                page__retest_page_missing_date=None,
             )
             .annotate(
                 position_pdf_page_last=DjangoCase(

--- a/accessibility_monitoring_platform/apps/audits/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_models.py
@@ -199,6 +199,9 @@ def test_audit_failed_check_results_for_deleted_page_not_returned():
     and associated page has not been deleted.
     """
     audit: Audit = create_audit_and_check_results()
+
+    assert len(audit.failed_check_results) == 3
+
     page: Page = Page.objects.get(audit=audit, page_type=PAGE_TYPE_PDF)
     page.is_deleted = True
     page.save()
@@ -213,6 +216,9 @@ def test_audit_failed_check_results_for_missing_page_not_returned():
     where retest page missing is not set.
     """
     audit: Audit = create_audit_and_check_results()
+
+    assert len(audit.failed_check_results) == 3
+
     page: Page = Page.objects.get(audit=audit, page_type=PAGE_TYPE_PDF)
     page.retest_page_missing_date = date.today()
     page.save()

--- a/accessibility_monitoring_platform/apps/audits/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_models.py
@@ -2,7 +2,7 @@
 Tests for cases models
 """
 import pytest
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import List
 from unittest.mock import patch, Mock
 
@@ -201,6 +201,20 @@ def test_audit_failed_check_results_for_deleted_page_not_returned():
     audit: Audit = create_audit_and_check_results()
     page: Page = Page.objects.get(audit=audit, page_type=PAGE_TYPE_PDF)
     page.is_deleted = True
+    page.save()
+
+    assert len(audit.failed_check_results) == 2
+
+
+@pytest.mark.django_db
+def test_audit_failed_check_results_for_missing_page_not_returned():
+    """
+    Test failed_check_results attribute of audit returns only check results
+    where retest page missing is not set.
+    """
+    audit: Audit = create_audit_and_check_results()
+    page: Page = Page.objects.get(audit=audit, page_type=PAGE_TYPE_PDF)
+    page.retest_page_missing_date = date.today()
     page.save()
 
     assert len(audit.failed_check_results) == 2


### PR DESCRIPTION
Trello card [#1190](https://trello.com/c/S3GtmYg1/1190-removed-pages-should-be-removed-from-the-final-stats-in-outstanding-issues-page).