### PR TITLE
1172: Remove report links from QA section of View case page

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/case_list.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/case_list.html
@@ -188,7 +188,7 @@
                                                         href="{% url 'reports:report-publisher' case.report.id %}"
                                                         class="govuk-link govuk-link--no-visited-state amp-margin-bottom-0"
                                                     >
-                                                        View report
+                                                        Report publisher
                                                     </a>
                                                 {% elif case.report_final_pdf_url %}
                                                     <a

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/qa_process.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/qa_process.html
@@ -33,14 +33,6 @@
         </tr>
         <tr class="govuk-table__row">
             <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">
-                Report draft
-            </th>
-            <td class="govuk-table__cell amp-width-one-half">
-                {% include 'cases/helpers/report_link_draft.html' %}
-            </td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">
                 Comments
             </th>
             <td class="govuk-table__cell amp-width-one-half">
@@ -53,20 +45,6 @@
             </th>
             <td class="govuk-table__cell amp-width-one-half">
                 {{ case.get_report_approved_status_display }}
-            </td>
-        </tr>
-        <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">
-                Published report
-            </th>
-            <td class="govuk-table__cell amp-width-one-half">
-                {% if case.report.latest_s3_report %}
-                    <a href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                        View final HTML report
-                    </a>
-                {% else %}
-                    None
-                {% endif %}
             </td>
         </tr>
         {% if case.report_methodology != 'platform' %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_details.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_details.html
@@ -18,15 +18,10 @@
         {% if case.report_methodology == 'platform' %}
             {% if case.report %}
                 <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">Link to report</th>
+                    <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">Preview report</th>
                     <td class="govuk-table__cell amp-width-one-half">
                         {% if case.report %}
-                            <a
-                                href="{% url 'reports:report-publisher' case.report.id %}"
-                                class="govuk-link govuk-link--no-visited-state"
-                            >
-                                View report
-                            </a>
+                            {% include 'cases/helpers/report_link_draft.html' %}
                         {% else %}
                             None
                         {% endif %}
@@ -34,7 +29,7 @@
                 </tr>
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">View final HTML report</th>
-                    <td class="govuk-table__cell amp-width-one-half amp-notes">
+                    <td class="govuk-table__cell amp-width-one-half">
                         {% if case.report.latest_s3_report %}
                             <a id="latest_s3_report" href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
                                 {{ case.report.latest_s3_report }}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1303,19 +1303,15 @@ def test_report_details_shows_link_to_create_report_when_no_report_exists_and_re
 @pytest.mark.parametrize(
     "audit_table_row",
     [
-        ("Link to report"),
+        ("Preview report"),
         ("Notes"),
         ("View final HTML report"),
         ("Report views"),
         ("Unique visitors to report"),
     ],
 )
-def test_report_shows_table_when_report_exists_and_report_is_platform(
-    admin_client, audit_table_row
-):
-    """
-    Test that audit details shows link to create when no audit exists
-    """
+def test_report_shows_expected_rows(admin_client, audit_table_row):
+    """Test that audit details shows expected rows"""
     case: Case = Case.objects.create()
     Audit.objects.create(case=case)
     Report.objects.create(case=case)
@@ -2312,7 +2308,7 @@ def test_platform_shows_notification_if_fully_compliant(
 @pytest.mark.parametrize(
     "report_methodology, report_link_label",
     [
-        (REPORT_METHODOLOGY_PLATFORM, "Link to report</th>"),
+        (REPORT_METHODOLOGY_PLATFORM, "Report publisher"),
         (REPORT_METHODOLOGY_ODT, "Link to report draft"),
     ],
 )


### PR DESCRIPTION
Trello card [#1172](https://trello.com/c/Zmp8yqAb/1172-review-how-qa-case-overview-page-represents-links-to-the-report).