### PR TITLE
1227: Restore preferred contact UI

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -36,6 +36,7 @@ from .models import (
     STATUS_CHOICES,
     CASE_COMPLETED_CHOICES,
     BOOLEAN_CHOICES,
+    PREFERRED_CHOICES,
     TWELVE_WEEK_RESPONSE_CHOICES,
     ENFORCEMENT_BODY_CHOICES,
     ENFORCEMENT_BODY_PURSUING_CHOICES,
@@ -309,14 +310,13 @@ class CaseContactUpdateForm(forms.ModelForm):
     name = AMPCharFieldWide(label="Name")
     job_title = AMPCharFieldWide(label="Job title")
     email = AMPCharFieldWide(label="Email")
+    preferred = AMPChoiceRadioField(
+        label="Preferred contact?", choices=PREFERRED_CHOICES
+    )
 
     class Meta:
         model = Case
-        fields = [
-            "name",
-            "job_title",
-            "email",
-        ]
+        fields = ["name", "job_title", "email", "preferred"]
 
 
 CaseContactFormset: Any = forms.modelformset_factory(

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1050,6 +1050,35 @@ def test_updating_report_sent_date(admin_client):
     )
 
 
+def test_preferred_contact_not_displayed_on_form(admin_client):
+    """
+    Test that the preferred contact field is not displayed when there is only one contact
+    """
+    case: Case = Case.objects.create()
+    Contact.objects.create(case=case)
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-contact-details", kwargs={"pk": case.id}),
+    )
+    assert response.status_code == 200
+    assertNotContains(response, "Preferred contact?")
+
+
+def test_preferred_contact_displayed_on_form(admin_client):
+    """
+    Test that the preferred contact field is displayed when there is more than one contact
+    """
+    case: Case = Case.objects.create()
+    Contact.objects.create(case=case)
+    Contact.objects.create(case=case)
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-contact-details", kwargs={"pk": case.id}),
+    )
+    assert response.status_code == 200
+    assertContains(response, "Preferred contact?")
+
+
 def test_report_followup_due_dates_not_changed(admin_client):
     """
     Test that populating the report sent date updates existing report followup due dates


### PR DESCRIPTION
Trello card [#1227](https://trello.com/c/yVNSJmJ0/1227-re-add-preferred-contact-field-design-attached).