### PR TITLE
1226: Remove automatic update of QA auditor on report approval

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -2169,26 +2169,6 @@ def test_frequently_used_links_displayed_in_edit(
         )
 
 
-def test_case_reviewer_updated_when_report_approved(admin_client, admin_user):
-    """
-    Test that the case QA auditor is set to the current user when report is approved
-    """
-    case: Case = Case.objects.create()
-
-    response: HttpResponse = admin_client.post(
-        reverse("cases:edit-qa-process", kwargs={"pk": case.id}),
-        {
-            "report_approved_status": "yes",
-            "version": case.version,
-            "save": "Save and continue",
-        },
-    )
-
-    assert response.status_code == 302
-    updated_case: Case = Case.objects.get(pk=case.id)
-    assert updated_case.reviewer == admin_user
-
-
 @pytest.mark.django_db
 def test_create_case_with_duplicates_shows_previous_url_field(admin_client):
     """

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -326,13 +326,6 @@ class CaseUpdateView(UpdateView):
             old_case: Case = Case.objects.get(pk=self.object.id)
             record_case_event(user=user, new_case=self.object, old_case=old_case)
 
-            if (
-                old_case.report_approved_status != self.object.report_approved_status
-                and self.object.report_approved_status
-                == REPORT_APPROVED_STATUS_APPROVED
-            ):
-                self.object.reviewer = self.request.user
-
             if "home_page_url" in form.changed_data:
                 self.object.domain = extract_domain_from_url(self.object.home_page_url)
 


### PR DESCRIPTION
Trello card [#1226](https://trello.com/c/RkPYLMZB/1226-remove-auto-assign-qa-auditor-when-report-is-approved).