### PR TITLE
1087: Move links to edit derived dates to be inline with page flow

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/report_correspondence.html
@@ -29,14 +29,6 @@
                 {% include 'common/error_summary.html' %}
                 <p class="govuk-body-m">
                     <a
-                        href="{% url 'cases:edit-report-followup-due-dates' case.id %}"
-                        class="govuk-link govuk-link--no-visited-state"
-                    >
-                        Edit report followup due dates
-                    </a>
-                </p>
-                <p class="govuk-body-m">
-                    <a
                         href="{% url 'cases:edit-no-psb-response' case.id %}"
                         class="govuk-link govuk-link--no-visited-state"
                     >
@@ -104,7 +96,11 @@
                             <hr class="amp-width-100">
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-one-half">
-                                    <label class="govuk-label"><b>12-week deadline</b></label>
+                                    <label class="govuk-label">
+                                        <b>12-week deadline</b> |
+                                        <a href="{% url 'cases:edit-report-followup-due-dates' case.id %}"
+                                            class="govuk-link govuk-link--no-visited-state">Edit</a>
+                                    </label>
                                 </div>
                                 <div class="govuk-grid-column-one-half">
                                     <span class="govuk-hint">

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/twelve_week_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/twelve_week_correspondence.html
@@ -45,14 +45,6 @@
                 {% else %}
                     <p class="govuk-body-m">
                         <a
-                            href="{% url 'cases:edit-twelve-week-correspondence-due-dates' case.id %}"
-                            class="govuk-link govuk-link--no-visited-state"
-                        >
-                            Edit 12-week correspondence due dates
-                        </a>
-                    </p>
-                    <p class="govuk-body-m">
-                        <a
                             href="{% url 'cases:twelve-week-correspondence-email' case.id %}"
                             class="govuk-link govuk-link--no-visited-state"
                         >
@@ -68,7 +60,11 @@
                             <div class="govuk-grid-column-full">
                                 <div class="govuk-grid-row">
                                     <div class="govuk-grid-column-one-half">
-                                        <label class="govuk-label"><b>12-week deadline</b></label>
+                                        <label class="govuk-label">
+                                            <b>12-week deadline</b> |
+                                            <a href="{% url 'cases:edit-twelve-week-correspondence-due-dates' case.id %}"
+                                                class="govuk-link govuk-link--no-visited-state">Edit</a>
+                                        </label>
                                     </div>
                                     <div class="govuk-grid-column-one-half">
                                         <span class="govuk-hint">

--- a/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
@@ -48,6 +48,7 @@ from ..utils import (
     download_equality_body_cases,
     download_cases,
     record_case_event,
+    build_edit_link_html,
 )
 
 ORGANISATION_NAME: str = "Organisation name one"
@@ -599,3 +600,14 @@ def test_record_case_event_reviewer_change():
     case_event = case_events[0]
     assert case_event.event_type == CASE_EVENT_QA_AUDITOR
     assert case_event.message == "QA auditor changed from Old User to New User"
+
+
+@pytest.mark.django_db
+def test_build_edit_link_html():
+    """Test building of edit link html for a case"""
+    case: Case = Case.objects.create()
+
+    assert (
+        build_edit_link_html(case=case, url_name="cases:edit-test-results")
+        == "<a href='/cases/1/edit-test-results/' class='govuk-link govuk-link--no-visited-state'>Edit</a>"
+    )

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1151,16 +1151,15 @@ def test_case_report_correspondence_view_contains_followup_due_dates(admin_clien
 
     assertContains(
         response,
-        f'<div class="govuk-hint">Due {amp_format_date(ONE_WEEK_FOLLOWUP_DUE_DATE)}</div>',
+        f"Due {amp_format_date(ONE_WEEK_FOLLOWUP_DUE_DATE)}",
     )
     assertContains(
         response,
-        f'<div class="govuk-hint">Due {amp_format_date(FOUR_WEEK_FOLLOWUP_DUE_DATE)}</div>',
+        f"{amp_format_date(FOUR_WEEK_FOLLOWUP_DUE_DATE)}",
     )
     assertContains(
         response,
-        f'<span class="govuk-hint">Due {amp_format_date(TWELVE_WEEK_FOLLOWUP_DUE_DATE)}</span>',
-        html=True,
+        f"Due {amp_format_date(TWELVE_WEEK_FOLLOWUP_DUE_DATE)}",
     )
 
 
@@ -2728,10 +2727,6 @@ def test_twelve_week_correspondence_psb_contact(admin_client):
     assertNotContains(
         response,
         "The public sector body has been as unresponsive to this case.",
-    )
-    assertContains(
-        response,
-        "Edit 12-week correspondence due dates",
     )
     assertContains(
         response,

--- a/accessibility_monitoring_platform/apps/cases/utils.py
+++ b/accessibility_monitoring_platform/apps/cases/utils.py
@@ -712,9 +712,7 @@ def record_case_event(
         )
 
 
-def build_edit_link_html(
-    case: Case, url_name: str = "cases:edit-report-followup-due-dates"
-) -> str:
+def build_edit_link_html(case: Case, url_name: str) -> str:
     """Return html of edit link for case"""
     case_pk: Dict[str, int] = {"pk": case.id}
     edit_url: str = reverse(url_name, kwargs=case_pk)

--- a/accessibility_monitoring_platform/apps/cases/utils.py
+++ b/accessibility_monitoring_platform/apps/cases/utils.py
@@ -13,6 +13,7 @@ from django.contrib.auth.models import User
 from django.db.models import Q, QuerySet
 from django.http import HttpResponse
 from django.http.request import QueryDict
+from django.urls import reverse
 
 from ..audits.models import Audit
 from ..common.utils import build_filters
@@ -709,3 +710,14 @@ def record_case_event(
             event_type=CASE_EVENT_CASE_COMPLETED,
             message=f"Case completed changed from '{old_status}' to '{new_status}'",
         )
+
+
+def build_edit_link_html(
+    case: Case, url_name: str = "cases:edit-report-followup-due-dates"
+) -> str:
+    """Return html of edit link for case"""
+    case_pk: Dict[str, int] = {"pk": case.id}
+    edit_url: str = reverse(url_name, kwargs=case_pk)
+    return (
+        f"<a href='{edit_url}' class='govuk-link govuk-link--no-visited-state'>Edit</a>"
+    )

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -86,6 +86,7 @@ from .utils import (
     replace_search_key_with_case_search,
     download_cases,
     record_case_event,
+    build_edit_link_html,
 )
 
 ONE_WEEK_IN_DAYS = 7
@@ -595,9 +596,9 @@ class CaseReportCorrespondenceUpdateView(CaseUpdateView):
         """Populate help text with dates"""
         form = super().get_form()
         case: Case = form.instance
-        case_pk: Dict[str, int] = {"pk": case.id}
-        edit_url: str = reverse("cases:edit-report-followup-due-dates", kwargs=case_pk)
-        edit_link_html: str = f"<a href='{edit_url}' class='govuk-link govuk-link--no-visited-state'>Edit</a>"
+        edit_link_html: str = build_edit_link_html(
+            case=form.instance, url_name="cases:edit-report-followup-due-dates"
+        )
 
         form.fields[
             "report_followup_week_1_sent_date"
@@ -667,12 +668,10 @@ class CaseTwelveWeekCorrespondenceUpdateView(CaseUpdateView):
     def get_form(self):
         """Populate help text with dates"""
         form = super().get_form()
-        case: Case = self.object
-        case_pk: Dict[str, int] = {"pk": case.id}
-        edit_url: str = reverse(
-            "cases:edit-twelve-week-correspondence-due-dates", kwargs=case_pk
+        edit_link_html: str = build_edit_link_html(
+            case=form.instance,
+            url_name="cases:edit-twelve-week-correspondence-due-dates",
         )
-        edit_link_html: str = f"<a href='{edit_url}' class='govuk-link govuk-link--no-visited-state'>Edit</a>"
         form.fields[
             "twelve_week_1_week_chaser_sent_date"
         ].help_text = f"{format_due_date_help_text(form.instance.twelve_week_1_week_chaser_due_date)} | {edit_link_html}"

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -595,12 +595,16 @@ class CaseReportCorrespondenceUpdateView(CaseUpdateView):
         """Populate help text with dates"""
         form = super().get_form()
         case: Case = form.instance
+        case_pk: Dict[str, int] = {"pk": case.id}
+        edit_url: str = reverse("cases:edit-report-followup-due-dates", kwargs=case_pk)
+        edit_link_html: str = f"<a href='{edit_url}' class='govuk-link govuk-link--no-visited-state'>Edit</a>"
+
         form.fields[
             "report_followup_week_1_sent_date"
-        ].help_text = format_due_date_help_text(case.report_followup_week_1_due_date)
+        ].help_text = f"{format_due_date_help_text(case.report_followup_week_1_due_date)} | {edit_link_html}"
         form.fields[
             "report_followup_week_4_sent_date"
-        ].help_text = format_due_date_help_text(case.report_followup_week_4_due_date)
+        ].help_text = f"{format_due_date_help_text(case.report_followup_week_4_due_date)} | {edit_link_html}"
         return form
 
     def form_valid(self, form: CaseReportCorrespondenceUpdateForm):
@@ -663,11 +667,15 @@ class CaseTwelveWeekCorrespondenceUpdateView(CaseUpdateView):
     def get_form(self):
         """Populate help text with dates"""
         form = super().get_form()
+        case: Case = self.object
+        case_pk: Dict[str, int] = {"pk": case.id}
+        edit_url: str = reverse(
+            "cases:edit-twelve-week-correspondence-due-dates", kwargs=case_pk
+        )
+        edit_link_html: str = f"<a href='{edit_url}' class='govuk-link govuk-link--no-visited-state'>Edit</a>"
         form.fields[
             "twelve_week_1_week_chaser_sent_date"
-        ].help_text = format_due_date_help_text(
-            form.instance.twelve_week_1_week_chaser_due_date
-        )
+        ].help_text = f"{format_due_date_help_text(form.instance.twelve_week_1_week_chaser_due_date)} | {edit_link_html}"
         return form
 
     def form_valid(self, form: CaseTwelveWeekCorrespondenceUpdateForm):

--- a/accessibility_monitoring_platform/apps/common/templates/common/amp_field_two_column.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/amp_field_two_column.html
@@ -12,7 +12,7 @@
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--l amp-margin-bottom-0">
                     <span class="govuk-label"><b>{{ field.label }}</b></span>
                 </legend>
-                {% if field.help_text %}<div class="govuk-hint">{{ field.help_text }}</div>{% endif %}
+                {% if field.help_text %}<div class="govuk-hint">{{ field.help_text|safe }}</div>{% endif %}
             </fieldset>
         {% else %}
             <label id="{{ field.auto_id }}-label" class="govuk-label" for="{{ field.auto_id }}"><b>{{ field.label }}</b></label>


### PR DESCRIPTION
Trello card [#1087](https://trello.com/c/wsyWhnfv/1087-combine-correspondence-due-dates-into-one-page).