### PR TITLE
1102: Add unresponsive column to equality body CSV

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
@@ -358,6 +358,7 @@ def test_download_equality_body_cases():
             "",
             "",
             "",
+            "No",
             "No claim",
             "",
             "No claim",

--- a/accessibility_monitoring_platform/apps/cases/utils.py
+++ b/accessibility_monitoring_platform/apps/cases/utils.py
@@ -108,6 +108,10 @@ COLUMNS_FOR_EQUALITY_BODY: List[ColumnAndFieldNames] = [
     ColumnAndFieldNames(
         column_name="Previous Case No.", field_name="previous_case_number"
     ),
+    ColumnAndFieldNames(
+        column_name="No response to report",
+        field_name="no_psb_contact",
+    ),
 ]
 
 EXTRA_AUDIT_COLUMNS_FOR_EQUALITY_BODY: List[ColumnAndFieldNames] = [


### PR DESCRIPTION
Trello card [#1102](https://trello.com/c/VPLY31KN/1102-add-psb-is-unrepsonsive-column-in-eb-csv-export).