### PR TITLE
1235: Add banner to report warning of outage 10-14 July 2023

### DIFF
--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -215,6 +215,10 @@ img, .amp-max-width-100 {
     margin-top: 10px;
 }
 
+.amp-margin-top-30 {
+    margin-top: 30px;
+}
+
 .amp-margin-top-minus-20 {
     margin-top: -20px;
 }

--- a/report_viewer/apps/viewer/tests.py
+++ b/report_viewer/apps/viewer/tests.py
@@ -3,9 +3,10 @@ Test report viewer
 """
 import pytest
 
+from datetime import date
 from typing import Dict, Optional, Union
-from unittest import mock
 import logging
+from unittest import mock
 
 from pytest_django.asserts import assertContains, assertNotContains
 from moto import mock_s3
@@ -31,6 +32,8 @@ from accessibility_monitoring_platform.apps.s3_read_write.models import S3Report
 from accessibility_monitoring_platform.apps.reports.models import ReportFeedback
 
 from .middleware.report_views_middleware import ReportMetrics
+
+from .utils import show_warning
 
 
 @pytest.mark.django_db
@@ -363,3 +366,18 @@ def test_post_report_feedback_form(admin_client):
         response,
         """Thank you for your feedback""",
     )
+
+
+@pytest.mark.parametrize(
+    "today, expected_result",
+    [
+        (date(2023, 7, 2), False),
+        (date(2023, 7, 3), True),
+        (date(2023, 7, 14), True),
+        (date(2023, 7, 15), False),
+    ],
+)
+def test_show_warning(today, expected_result):
+    with mock.patch("report_viewer.apps.viewer.utils.date") as mock_date:
+        mock_date.today.return_value = today
+        assert show_warning() is expected_result

--- a/report_viewer/apps/viewer/utils.py
+++ b/report_viewer/apps/viewer/utils.py
@@ -1,0 +1,10 @@
+"""Uitility functions for report viewer"""
+from datetime import date
+
+SHOW_WARNING_START_DATE: date = date(2023, 7, 3)
+SHOW_WARNING_END_DATE: date = date(2023, 7, 14)
+
+
+def show_warning() -> bool:
+    today: date = date.today()
+    return today >= SHOW_WARNING_START_DATE and today <= SHOW_WARNING_END_DATE

--- a/report_viewer/apps/viewer/views.py
+++ b/report_viewer/apps/viewer/views.py
@@ -17,6 +17,8 @@ from accessibility_monitoring_platform.apps.s3_read_write.utils import (
 )
 from accessibility_monitoring_platform.apps.s3_read_write.models import S3Report
 
+from .utils import show_warning
+
 FORM_SUBMITTED_SUCCESSFULLY: str = "Form submitted successfully"
 
 logger = logging.getLogger(__name__)
@@ -70,6 +72,7 @@ class ViewReport(FormView):
                 "guid": self.kwargs["guid"],
                 "form_submitted": form_submitted_successfully,
                 "report_viewer": True,
+                "show_warning": show_warning(),
             }
         )
         return context

--- a/report_viewer/templates/base.html
+++ b/report_viewer/templates/base.html
@@ -54,6 +54,15 @@
       </header>
 
       <div class="govuk-width-container">
+        <div class="govuk-warning-text amp-margin-top-30 amp-margin-bottom-0">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+                <span class="govuk-warning-text__assistive">Warning</span>
+                Necessary maintenance will take place  between Monday 10th of
+                July and Friday 14th of July 2023. Reports may be inaccessible
+                during that time.
+            </strong>
+        </div>
         {% block content %}
         {% endblock %}
       </div>

--- a/report_viewer/templates/base.html
+++ b/report_viewer/templates/base.html
@@ -54,15 +54,17 @@
       </header>
 
       <div class="govuk-width-container">
-        <div class="govuk-warning-text amp-margin-top-30 amp-margin-bottom-0">
-            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-            <strong class="govuk-warning-text__text">
-                <span class="govuk-warning-text__assistive">Warning</span>
-                Necessary maintenance will take place  between Monday 10th of
-                July and Friday 14th of July 2023. Reports may be inaccessible
-                during that time.
-            </strong>
-        </div>
+        {% if show_warning %}
+            <div class="govuk-warning-text amp-margin-top-30 amp-margin-bottom-0">
+                <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+                <strong class="govuk-warning-text__text">
+                    <span class="govuk-warning-text__assistive">Warning</span>
+                    Maintenance will take place between Monday 10 July and Friday 14 July 2023.
+                    <br>
+                    Reports may be inaccessible during that time.
+                </strong>
+            </div>
+        {% endif %}
         {% block content %}
         {% endblock %}
       </div>


### PR DESCRIPTION
Trello card [#1235](https://trello.com/c/F0wbcWqO/1235-add-banner-to-warn-public-orgs-about-the-site-going-down-during-cloud-migration-design-attached).