### PR TITLE
1245: Change button labels on Report publisher page

### DIFF
--- a/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
@@ -26,13 +26,24 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <div class="govuk-button-group">
+                    {% if report.case.published_report_url %}
+                        <a href="{{ report.case.published_report_url }}"
+                            role="button"
+                            draggable="false"
+                            class="govuk-button govuk-button--secondary"
+                            data-module="govuk-button"
+                            target="_blank"
+                        >
+                            View final HTML report
+                        </a>
+                    {% endif %}
                     <a href="{% url 'reports:report-confirm-publish' report.id %}"
                         role="button"
                         draggable="false"
                         class="govuk-button"
                         data-module="govuk-button"
                     >
-                        Publish HTML report
+                        {% if report.case.published_report_url %}Republish{% else %}Publish{% endif%} HTML report
                     </a>
                     <a
                         href="{% url 'cases:edit-report-details' report.case.id %}"
@@ -40,11 +51,6 @@
                     >
                         Return to case &gt; Report details
                     </a>
-                    {% if report.case.published_report_url %}
-                        <a href="{{ report.case.published_report_url }}" class="govuk-link" target="_blank">
-                            View published report
-                        </a>
-                    {% endif %}
                 </div>
             </div>
         </div>

--- a/accessibility_monitoring_platform/apps/reports/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/reports/tests/test_views.py
@@ -217,6 +217,47 @@ def test_report_specific_page_loads(path_name, expected_header, admin_client):
     assertContains(response, expected_header)
 
 
+def test_button_to_published_report_shown(admin_client):
+    """
+    Test button link to published report shown if published report exists
+    """
+    case: Case = Case.objects.create()
+    Audit.objects.create(case=case)
+    report: Report = Report.objects.create(case=case)
+    S3Report.objects.create(case=case, version=0, latest_published=True)
+    report_pk_kwargs: Dict[str, int] = {"pk": report.id}
+
+    response: HttpResponse = admin_client.get(
+        reverse("reports:report-publisher", kwargs=report_pk_kwargs)
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, "View final HTML report")
+    assertContains(response, "Republish HTML report")
+    assertNotContains(response, "Publish HTML report")
+
+
+def test_button_to_published_report_not_shown(admin_client):
+    """
+    Test button link to published report not shown if report not published
+    """
+    case: Case = Case.objects.create()
+    Audit.objects.create(case=case)
+    report: Report = Report.objects.create(case=case)
+    report_pk_kwargs: Dict[str, int] = {"pk": report.id}
+
+    response: HttpResponse = admin_client.get(
+        reverse("reports:report-publisher", kwargs=report_pk_kwargs)
+    )
+
+    assert response.status_code == 200
+
+    assertNotContains(response, "View final HTML report")
+    assertNotContains(response, "Republish HTML report")
+    assertContains(response, "Publish HTML report")
+
+
 def test_report_next_step_for_not_started(admin_client):
     """
     Test report next step for report review not started


### PR DESCRIPTION
Trello card [#1245](https://trello.com/c/9kkArby4/1245-redesign-headline-buttons-in-report-publisher-design-attached).