### PR TITLE
1247: Add another link to the latest HTML report

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -1767,7 +1767,7 @@ def test_frequently_used_links_displayed(url_name, admin_client):
     assertContains(response, "Frequently used links")
     assertContains(response, "View outstanding issues")
     assertContains(response, "View email template")
-    assertContains(response, "No published report")
+    assertContains(response, "No report has been published")
     assertContains(response, "View website")
     assertContains(response, "Link to case view")
     assertContains(response, "Markdown cheatsheet")

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/overview.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/overview.html
@@ -13,6 +13,16 @@
         {{ case.home_page_url }}
         </a>
     </p>
+    <h2 class="govuk-heading-s amp-margin-bottom-5">Published report</h2>
+    <p class="govuk-body-m amp-margin-bottom-10">
+        {% if case.report.latest_s3_report %}
+            <a href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
+                View final HTML report
+            </a>
+        {% else %}
+            No report has been published
+        {% endif %}
+    </p>
     <h2 class="govuk-heading-s amp-margin-bottom-5">Website issues</h2>
     <p class="govuk-body-m amp-margin-bottom-10">{{ case.overview_issues_website }}</p>
     <h2 class="govuk-heading-s amp-margin-bottom-5">Statement issues</h2>

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -3373,7 +3373,7 @@ def test_frequently_used_links_displayed(url_name, admin_client):
     assertContains(response, "Frequently used links")
     assertContains(response, "View outstanding issues")
     assertContains(response, "View email template")
-    assertContains(response, "No published report")
+    assertContains(response, "No report has been published")
     assertContains(response, "View website")
 
 

--- a/accessibility_monitoring_platform/apps/common/templates/common/frequently_used_links.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/frequently_used_links.html
@@ -31,10 +31,10 @@
     <li>
         {% if case.report.latest_s3_report %}
             <a href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                View published report
+                View final HTML report
             </a>
         {% else %}
-            No published report
+            No report has been published
         {% endif %}
     </li>
     <li>


### PR DESCRIPTION
Trello card [#1247](https://trello.com/c/LVldHokh/1247-make-it-easier-to-get-to-the-published-report-design-attached).