### PR TITLE
1265: Show/hide links to Report options/Statement overview in Report publisher

### DIFF
--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/nav_contents.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/nav_contents.html
@@ -21,8 +21,13 @@
                     {% endfor %}
                 </ul>
             </li>
-            {% include './nav_content.html' with anchor='report-your-accessibility-statement' name='Your accessibility statement' edit_url='audits:edit-audit-report-options' edit_label='Edit test &gt; Report options' %}
-            {% include './nav_content.html' with anchor='report-what-to-do-next' name='What to do next'  edit_url='audits:edit-audit-report-options' edit_label='Edit test &gt; Report options' %}
+            {% if report.case.audit.uses_statement_checks %}
+                {% include './nav_content.html' with anchor='report-your-accessibility-statement' name='Your accessibility statement' edit_url='audits:edit-statement-overview' edit_label='Edit test &gt; Statement overview' %}
+                {% include './nav_content.html' with anchor='report-what-to-do-next' name='What to do next' %}
+            {% else %}
+                {% include './nav_content.html' with anchor='report-your-accessibility-statement' name='Your accessibility statement' edit_url='audits:edit-audit-report-options' edit_label='Edit test &gt; Report options' %}
+                {% include './nav_content.html' with anchor='report-what-to-do-next' name='What to do next'  edit_url='audits:edit-audit-report-options' edit_label='Edit test &gt; Report options' %}
+            {% endif %}
             {% include './nav_content.html' with anchor='report-enforcement' name='Enforcement' %}
             {% include './nav_content.html' with anchor='report-contact-and-more-information' name='Contact and more information' %}
 


### PR DESCRIPTION
Trello card [#1265](https://trello.com/c/3uYh2vVB/1265-report-options-still-in-report-wrapper).