### PR TITLE
1277: Upgrade GDS design system to 4.7.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "4.6.0",
+        "govuk-frontend": "4.7.0",
         "showdown": "2.1.0"
       },
       "devDependencies": {
@@ -8926,9 +8926,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -28635,9 +28635,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.6.0.tgz",
-      "integrity": "sha512-pLJVHVvfsTmNDBH/YBCMyuqSMCQmOrNQXoThdcAzhXJVbuaWnGc1URvjOR7EJeZyOm101fHDjzTkTvpEy6zfiw=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "graceful-fs": {
       "version": "4.2.10",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "4.6.0",
+    "govuk-frontend": "4.7.0",
     "showdown": "2.1.0"
   },
   "standard": {


### PR DESCRIPTION
Trello card [#1277](https://trello.com/c/Pm03I2lR/1277-upgrade-gds-design-system-to-470).