### PR TITLE
1337: Add check of response headers to smoke tests

### DIFF
--- a/.github/workflows/platform-checking.yml
+++ b/.github/workflows/platform-checking.yml
@@ -1,9 +1,7 @@
 name: Check test and production platforms
-on: pull_request
-# on:
-#   schedule:
-#     - cron: '10 9 * * *'  # At 9:10am
-#     # - cron: '0 9 * * 1-5'  # Mon-Fri at 9am
+on:
+  schedule:
+    - cron: '0 9 * * 1-5'  # Mon-Fri at 9am
 jobs:
   check:
     name: Check test and production platforms

--- a/.github/workflows/platform-checking.yml
+++ b/.github/workflows/platform-checking.yml
@@ -20,4 +20,4 @@ jobs:
         source venv/bin/activate
         pip install --upgrade pip
         pip install requests
-        python3 check_headers.py
+        python3 check_platforms.py

--- a/.github/workflows/platform-checking.yml
+++ b/.github/workflows/platform-checking.yml
@@ -1,0 +1,23 @@
+name: Check test and production platforms
+on: pull_request
+# on:
+#   schedule:
+#     - cron: '10 9 * * *'  # At 9:10am
+#     # - cron: '0 9 * * 1-5'  # Mon-Fri at 9am
+jobs:
+  check:
+    name: Check test and production platforms
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.11'
+    - name: Check response headers
+      run: |
+        python3 -m venv venv
+        source venv/bin/activate
+        pip install --upgrade pip
+        pip install requests
+        python3 check_headers.py

--- a/check_headers.py
+++ b/check_headers.py
@@ -1,0 +1,25 @@
+import requests
+
+
+def check_response(response):
+    assert (
+        response.status_code == 200
+    ), f"Unexpected response status: {response.status_code}"
+    assert (
+        "Strict-Transport-Security" in response.headers
+    ), "Strict-Transport-Security header missing"
+    assert (
+        response.headers["Strict-Transport-Security"]
+        == "max-age=2592000; includeSubDomains; preload"
+    ), f"Unexpected Strict-Transport-Security: {response.headers['Strict-Transport-Security']}"
+
+
+def main():
+    for url in [
+        "https://platform-test.accessibility-monitoring.service.gov.uk/",
+        "https://platform-test.accessibility-monitoring.service.gov.uk/admin/",
+        "https://platform.accessibility-monitoring.service.gov.uk/",
+        "https://platform.accessibility-monitoring.service.gov.uk/admin/",
+    ]:
+        response = requests.get(url)
+        check_response(response)

--- a/check_headers.py
+++ b/check_headers.py
@@ -23,3 +23,7 @@ def main():
     ]:
         response = requests.get(url)
         check_response(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/check_platforms.py
+++ b/check_platforms.py
@@ -4,17 +4,18 @@ Check production and test platforms are working. Non-destructive checks only!
 import requests
 
 
-def check_response(response):
+def check_url(url: str):
+    response: requests.models.Response = requests.get(url)
     assert (
         response.status_code == 200
-    ), f"Unexpected response status: {response.status_code}"
+    ), f"Unexpected response status: {response.status_code} (on {url})"
     assert (
         "Strict-Transport-Security" in response.headers
-    ), "Strict-Transport-Security header missing"
+    ), f"Strict-Transport-Security header missing (on {url})"
     assert (
         response.headers["Strict-Transport-Security"]
         == "max-age=2592000; includeSubDomains; preload"
-    ), f"Unexpected Strict-Transport-Security: {response.headers['Strict-Transport-Security']}"
+    ), f"Unexpected Strict-Transport-Security: {response.headers['Strict-Transport-Security']} (on {url})"
 
 
 def main():
@@ -24,9 +25,7 @@ def main():
         "https://platform.accessibility-monitoring.service.gov.uk/",
         "https://platform.accessibility-monitoring.service.gov.uk/admin/",
     ]:
-        print(f"Checking {url}")
-        response = requests.get(url)
-        check_response(response)
+        check_url(url)
 
 
 if __name__ == "__main__":

--- a/check_platforms.py
+++ b/check_platforms.py
@@ -23,7 +23,7 @@ def main():
         "https://platform-test.accessibility-monitoring.service.gov.uk/",
         "https://platform-test.accessibility-monitoring.service.gov.uk/platform-admin/",
         "https://platform.accessibility-monitoring.service.gov.uk/",
-        "https://platform.accessibility-monitoring.service.gov.uk/admin/",
+        "https://platform.accessibility-monitoring.service.gov.uk/platform-admin/",
     ]:
         check_url(url)
 

--- a/check_platforms.py
+++ b/check_platforms.py
@@ -1,3 +1,6 @@
+"""
+Check production and test platforms are working. Non-destructive checks only!
+"""
 import requests
 
 
@@ -21,6 +24,7 @@ def main():
         "https://platform.accessibility-monitoring.service.gov.uk/",
         "https://platform.accessibility-monitoring.service.gov.uk/admin/",
     ]:
+        print(f"Checking {url}")
         response = requests.get(url)
         check_response(response)
 

--- a/check_platforms.py
+++ b/check_platforms.py
@@ -1,5 +1,5 @@
 """
-Check production and test platforms are working. Non-destructive checks only!
+Check test and test platforms are working. Non-destructive checks only!
 """
 import requests
 
@@ -21,7 +21,7 @@ def check_url(url: str):
 def main():
     for url in [
         "https://platform-test.accessibility-monitoring.service.gov.uk/",
-        "https://platform-test.accessibility-monitoring.service.gov.uk/admin/",
+        "https://platform-test.accessibility-monitoring.service.gov.uk/platform-admin/",
         "https://platform.accessibility-monitoring.service.gov.uk/",
         "https://platform.accessibility-monitoring.service.gov.uk/admin/",
     ]:

--- a/stack_tests/integration_tests/cypress/e2e/production_test.cy.js
+++ b/stack_tests/integration_tests/cypress/e2e/production_test.cy.js
@@ -1,0 +1,24 @@
+/* global cy, Cypress */
+
+const hstsHeaderName = 'strict-transport-security'
+const hstsHeaderValue = 'max-age=2592000; includeSubDomains; preload'
+
+describe('Platform test response headers', () => {
+  const domain = 'platform-test.accessibility-monitoring.service.gov.uk'
+  it('include strict transport security', () => {
+    cy.request(`https://${domain}/`).then((response) => {
+      expect(response).to.have.property('headers')
+      expect(response.headers).to.have.property(hstsHeaderName, hstsHeaderValue)
+    })
+  })
+})
+
+describe('Platform production response headers', () => {
+  const domain = 'platform.accessibility-monitoring.service.gov.uk'
+  it('include strict transport security', () => {
+    cy.request(`https://${domain}/`).then((response) => {
+      expect(response).to.have.property('headers')
+      expect(response.headers).to.have.property(hstsHeaderName, hstsHeaderValue)
+    })
+  })
+})

--- a/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
+++ b/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
@@ -1,0 +1,10 @@
+
+/* global cy, Cypress */
+
+describe('Response headers', () => {
+  it('include strict transport security', () => {
+    cy.resuest('/').then((response) => {
+      expect(response).to.have.property('headers')
+      expect(response.headers).to.have.property('Strict-Transport-Security', 'max-age=2592000; includeSubDomains; preload')
+  })
+})

--- a/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
+++ b/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
@@ -1,10 +1,11 @@
 
 /* global cy, Cypress */
 
-describe('Response headers', () => {
+describe('Platform production Response headers', () => {
   it('include strict transport security', () => {
-    cy.resuest('/').then((response) => {
+    cy.request('https://platform.accessibility-monitoring.service.gov.uk/').then((response) => {
       expect(response).to.have.property('headers')
-      expect(response.headers).to.have.property('Strict-Transport-Security', 'max-age=2592000; includeSubDomains; preload')
+      expect(response.headers).to.have.property('strict-transport-security', 'max-age=2592000; includeSubDomains; preload')
+    })
   })
 })

--- a/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
+++ b/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
@@ -1,27 +1,14 @@
 
 /* global cy, Cypress */
 
-describe('Platform staging response headers', () => {
+const hstsHeaderName = 'strict-transport-security'
+const hstsHeaderValue = 'max-age=2592000; includeSubDomains; preload'
+
+describe('Platform response headers', () => {
   it('include strict transport security', () => {
     cy.request('/').then((response) => {
       expect(response).to.have.property('headers')
-      expect(response.headers).to.have.property('strict-transport-security', 'max-age=2592000; includeSubDomains; preload')
-    })
-  })
-})
-describe('Platform test response headers', () => {
-  it('include strict transport security', () => {
-    cy.request('https://platform-test.accessibility-monitoring.service.gov.uk/').then((response) => {
-      expect(response).to.have.property('headers')
-      expect(response.headers).to.have.property('strict-transport-security', 'max-age=2592000; includeSubDomains; preload')
-    })
-  })
-})
-describe('Platform production response headers', () => {
-  it('include strict transport security', () => {
-    cy.request('https://platform.accessibility-monitoring.service.gov.uk/').then((response) => {
-      expect(response).to.have.property('headers')
-      expect(response.headers).to.have.property('strict-transport-security', 'max-age=2592000; includeSubDomains; preload')
+      expect(response.headers).to.have.property(hstsHeaderName, hstsHeaderValue)
     })
   })
 })

--- a/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
+++ b/stack_tests/smoke_tests/cypress/e2e/headers.cy.js
@@ -1,7 +1,23 @@
 
 /* global cy, Cypress */
 
-describe('Platform production Response headers', () => {
+describe('Platform staging response headers', () => {
+  it('include strict transport security', () => {
+    cy.request('/').then((response) => {
+      expect(response).to.have.property('headers')
+      expect(response.headers).to.have.property('strict-transport-security', 'max-age=2592000; includeSubDomains; preload')
+    })
+  })
+})
+describe('Platform test response headers', () => {
+  it('include strict transport security', () => {
+    cy.request('https://platform-test.accessibility-monitoring.service.gov.uk/').then((response) => {
+      expect(response).to.have.property('headers')
+      expect(response.headers).to.have.property('strict-transport-security', 'max-age=2592000; includeSubDomains; preload')
+    })
+  })
+})
+describe('Platform production response headers', () => {
   it('include strict transport security', () => {
     cy.request('https://platform.accessibility-monitoring.service.gov.uk/').then((response) => {
       expect(response).to.have.property('headers')


### PR DESCRIPTION
Trelo card [#1337](https://trello.com/c/KdLAPdzG/1337-research-whether-we-can-do-some-basic-security-tests-during-deployment-tests).