### PR TITLE
1334: Show published report version and date

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_details.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_details.html
@@ -28,7 +28,7 @@
                     </td>
                 </tr>
                 <tr class="govuk-table__row">
-                    <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">View final HTML report</th>
+                    <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">View published HTML report</th>
                     <td class="govuk-table__cell amp-width-one-half">
                         {% if case.report.latest_s3_report %}
                             <a id="latest_s3_report" href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
@@ -65,7 +65,7 @@
                                     <div class="govuk-hint">
                                         {% if case.report.latest_s3_report %}
                                             <a href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                                                View final HTML report
+                                                View published HTML report
                                             </a>
                                         {% else %}
                                             HTML report has not been published. Publish report in

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/overview.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/overview.html
@@ -17,7 +17,7 @@
     <p class="govuk-body-m amp-margin-bottom-10">
         {% if case.report.latest_s3_report %}
             <a href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                View final HTML report
+                View published HTML report
             </a>
         {% else %}
             No report has been published

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/status_requirements.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/status_requirements.html
@@ -19,7 +19,7 @@
 <p class="govuk-body-m">
     {% if case.report.latest_s3_report %}
         <a href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-            View final HTML report
+            View published HTML report
         </a>
     {% else %}
         None

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1343,7 +1343,7 @@ def test_report_details_shows_link_to_create_report_when_no_report_exists_and_re
     [
         ("Preview report"),
         ("Notes"),
-        ("View final HTML report"),
+        ("View published HTML report"),
         ("Report views"),
         ("Unique visitors to report"),
     ],
@@ -2647,7 +2647,7 @@ def test_platform_qa_process_shows_link_to_s3_report(admin_client):
             <div class="govuk-hint">
                 <a href="{s3_report_url}" rel="noreferrer noopener"
                     target="_blank" class="govuk-link">
-                    View final HTML report
+                    View published HTML report
                 </a>
             </div>
         </div>""",
@@ -2657,7 +2657,7 @@ def test_platform_qa_process_shows_link_to_s3_report(admin_client):
 
 def test_non_platform_qa_process_shows_final_report_fields(admin_client):
     """
-    Test that the QA process page shows the final report fields
+    Test that the QA process page shows the published report fields
     when the report methodology is not platform.
     """
     case: Case = Case.objects.create(report_methodology=REPORT_METHODOLOGY_ODT)
@@ -2673,7 +2673,7 @@ def test_non_platform_qa_process_shows_final_report_fields(admin_client):
 
 def test_platform_qa_process_does_not_show_final_report_fields(admin_client):
     """
-    Test that the QA process page does not show the final report fields
+    Test that the QA process page does not show the published report fields
     when the report methodology is platform.
     """
     case: Case = Case.objects.create()

--- a/accessibility_monitoring_platform/apps/common/templates/common/frequently_used_links.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/frequently_used_links.html
@@ -31,7 +31,7 @@
     <li>
         {% if case.report.latest_s3_report %}
             <a href="{{ case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                View final HTML report
+                View published HTML report
             </a>
         {% else %}
             No report has been published

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/overview.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/overview.html
@@ -3,6 +3,14 @@
 <h2 class="govuk-heading-m">Overview</h2>
 <div class="amp-left-border">
     {% include 'reports/helpers/overview_status.html' %}
+    <h2 class="govuk-heading-s amp-margin-bottom-5">Version number and date published</h2>
+    <p class="govuk-body amp-margin-bottom-10">
+        {% if report.latest_s3_report %}
+            {{ report.latest_s3_report }}
+        {% else %}
+            None
+        {% endif %}
+    </p>
     <h2 class="govuk-heading-s amp-margin-bottom-5">Auditor</h2>
     <p class="govuk-body amp-margin-bottom-10">
         {% if report.case.auditor %}

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/overview_status.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/helpers/overview_status.html
@@ -23,18 +23,18 @@
             The platform has identified changes to the test since publishing the report.
             <a href="{% url 'reports:report-confirm-publish' report.id %}" class="govuk-link govuk-link--no-visited-state">
                 Republish the report</a>
-            to update the final report.
+            to update the published report.
         </p>
         <p class="govuk-body">
             View the
             <a href="{{ report.case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                final HTML report</a>
+                published HTML report</a>
         </p>
     {% else %}
         <p class="govuk-body amp-margin-bottom-10">
             The report has been published. View the
             <a href="{{ report.case.published_report_url }}" rel="noreferrer noopener" target="_blank" class="govuk-link">
-                final HTML report</a>
+                published HTML report</a>
         </p>
         <p class="govuk-body">
             <a href="{% url 'cases:edit-report-details' report.case.id %}" class="govuk-link govuk-link--no-visited-state">

--- a/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
+++ b/accessibility_monitoring_platform/apps/reports/templates/reports/report_publisher.html
@@ -22,7 +22,7 @@
                             data-module="govuk-button"
                             target="_blank"
                         >
-                            View final HTML report
+                            View published HTML report
                         </a>
                     {% endif %}
                     <a href="{% url 'reports:report-confirm-publish' report.id %}"

--- a/accessibility_monitoring_platform/apps/reports/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/reports/tests/test_views.py
@@ -308,7 +308,7 @@ def test_button_to_published_report_shown(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "View final HTML report")
+    assertContains(response, "View published HTML report")
     assertContains(response, "Republish HTML report")
     assertNotContains(response, "Publish HTML report")
 
@@ -328,7 +328,7 @@ def test_button_to_published_report_not_shown(admin_client):
 
     assert response.status_code == 200
 
-    assertNotContains(response, "View final HTML report")
+    assertNotContains(response, "View published HTML report")
     assertNotContains(response, "Republish HTML report")
     assertContains(response, "Publish HTML report")
 

--- a/stack_tests/integration_tests/cypress/e2e/new_case_test_report.cy.js
+++ b/stack_tests/integration_tests/cypress/e2e/new_case_test_report.cy.js
@@ -115,7 +115,7 @@ describe('Create case, tests and report', () => {
 
     cy.title().should('eq', `${newOrganisationName} | Report publisher`)
     cy.contains('HTML report successfully created!')
-    cy.contains('final HTML report')
+    cy.contains('published HTML report')
 
     cy.contains('Case').click()
     cy.contains('View case').click()

--- a/stack_tests/integration_tests/cypress/e2e/report.cy.js
+++ b/stack_tests/integration_tests/cypress/e2e/report.cy.js
@@ -17,7 +17,7 @@ describe('Report publisher', () => {
   })
 
   it('contains link to latest published HTML report', () => {
-    cy.contains('final HTML report')
+    cy.contains('published HTML report')
       .should('have.attr', 'href')
       .then((href) => {
         expect(href).to.include('/reports/96b1afce-a445-42c3-961c-7708aba196f3')


### PR DESCRIPTION
Trello card [#1334](https://trello.com/c/cwaUdVSN/1334-add-published-time-and-version-number-to-report-overview-design-attached) and [#1257](https://trello.com/c/PiylNn7t/1257-change-final-report-to-published-report-in-the-platform).