### PR TITLE
1360: Fix link to report preview; Remove Contact notes

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/contact_details.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/contact_details.html
@@ -46,10 +46,6 @@
                         <td class="govuk-table__cell amp-width-one-half">{{ contact.get_preferred_display }}</td>
                     </tr>
                 {% endif %}
-                <tr class="govuk-table__row">
-                    <td class="govuk-table__cell amp-width-one-half">Contact {{ forloop.counter }} Notes</td>
-                    <td class="govuk-table__cell amp-width-one-half">{{ contact.notes|markdown_to_html }}</td>
-                </tr>
             {% endfor %}
         </tbody>
     </table>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/report_link_draft.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/report_link_draft.html
@@ -1,6 +1,6 @@
 {% if case.report_methodology == 'platform' %}
     {% if case.report %}
-        <a href="{% url 'reports:report-publisher' case.report.id %}" rel="noreferrer noopener" target="_blank" class="govuk-link govuk-link--no-visited-state">
+        <a href="{% url 'reports:report-publisher' case.report.id %}" rel="noreferrer noopener" class="govuk-link govuk-link--no-visited-state">
             Report publisher
         </a>
     {% else %}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -2579,7 +2579,7 @@ def test_platform_qa_process_shows_link_to_preview_report(admin_client):
         f"""<div class="govuk-form-group">
             <label class="govuk-label"><b>Link to report draft</b></label>
             <div class="govuk-hint">
-                <a href="{report_publisher_url}" rel="noreferrer noopener" target="_blank" class="govuk-link govuk-link--no-visited-state">
+                <a href="{report_publisher_url}" rel="noreferrer noopener" class="govuk-link govuk-link--no-visited-state">
                     Report publisher
                 </a>
             </div>


### PR DESCRIPTION
Trello card [#1360](https://trello.com/c/ndWxfyNg/1360-sanitise-pii-from-prototype-data-backup).