### PR TITLE
0002 middleware

### DIFF
--- a/accessibility_monitoring_platform/apps/common/middleware/validate_host_middleware.py
+++ b/accessibility_monitoring_platform/apps/common/middleware/validate_host_middleware.py
@@ -1,0 +1,22 @@
+""" Check requests are for valid hosts """
+import logging
+
+from django.core.exceptions import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class ValidateHostMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        host: str = request.get_host()
+        if host.startswith("localhost") or host.startswith("10.0."):
+            logger.info("Expected host %s", host)
+        else:
+            raise ValidationError(f"Unexpected host in request: {host}")
+
+        response = self.get_response(request)
+
+        return response

--- a/accessibility_monitoring_platform/apps/common/middleware/validate_host_middleware.py
+++ b/accessibility_monitoring_platform/apps/common/middleware/validate_host_middleware.py
@@ -8,7 +8,7 @@ from django.http.request import split_domain_port, validate_host
 
 logger = logging.getLogger(__name__)
 
-IP_REGEX = re.compile(r"10.0\.[0-9]{1,3}\.[0-9]{1,3}")
+VALID_IP_REGEX = re.compile(r"10.0\.[0-9]{1,3}\.[0-9]{1,3}")
 
 
 class ValidateHostMiddleware:
@@ -18,7 +18,9 @@ class ValidateHostMiddleware:
     def __call__(self, request):
         host: str = request.get_host()
         domain, _ = split_domain_port(host)
-        if validate_host(domain, settings.ALLOWED_HOSTS) or IP_REGEX.fullmatch(domain):
+        if validate_host(domain, settings.ALLOWED_HOSTS) or VALID_IP_REGEX.fullmatch(
+            domain
+        ):
             logger.info("Valid host found: %s", host)
         else:
             raise DisallowedHost(f"Unexpected host in request: {host}")

--- a/accessibility_monitoring_platform/apps/common/tests/test_middleware.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_middleware.py
@@ -36,6 +36,7 @@ def test_validate_host_middleware_valid_host(mock_logger, host):
     mock_request.get_host.return_value = host
     validate_host_middleware = ValidateHostMiddleware(Mock())
     validate_host_middleware(mock_request)
+
     mock_logger.assert_called_once_with("Valid host found: %s", host)
 
 

--- a/accessibility_monitoring_platform/apps/common/tests/test_middleware.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_middleware.py
@@ -1,9 +1,12 @@
 """ test_middleware - Tests for common middleware"""
-
-from django.urls import reverse
 import pytest
+from unittest.mock import patch, Mock
+
+from django.core.exceptions import DisallowedHost
+from django.urls import reverse
 
 from ..models import UserCacheUniqueHash
+from ..middleware.validate_host_middleware import ValidateHostMiddleware
 
 
 @pytest.mark.django_db
@@ -14,3 +17,36 @@ def test_middleware_caches_user_unique_id(client, django_user_model):
     client.force_login(user)
     client.get(reverse("dashboard:home"))
     assert UserCacheUniqueHash.objects.all().count() == 1
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "localhost",
+        "10.0.1.2",
+        "10.0.3.4",
+    ],
+)
+@patch(
+    "accessibility_monitoring_platform.apps.common.middleware.validate_host_middleware.logger.info"
+)
+def test_validate_host_middleware_valid_host(mock_logger, host):
+    """Tests host validation for valid host"""
+    mock_request = Mock()
+    mock_request.get_host.return_value = host
+    validate_host_middleware = ValidateHostMiddleware(Mock())
+    validate_host_middleware(mock_request)
+    mock_logger.assert_called_once_with("Valid host found: %s", host)
+
+
+def test_validate_host_middleware_invalid_host():
+    """Tests host validation for invalid host"""
+    host: str = "invalid.com"
+    mock_request = Mock()
+    mock_request.get_host.return_value = host
+    validate_host_middleware = ValidateHostMiddleware(Mock())
+
+    with pytest.raises(DisallowedHost) as excinfo:
+        validate_host_middleware(mock_request)
+
+    assert f"Unexpected host in request: {host}" in str(excinfo.value)

--- a/accessibility_monitoring_platform/apps/common/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_views.py
@@ -1177,7 +1177,10 @@ def test_navbar_overdue_emboldened(admin_client, admin_user):
     )
 
 
-def test_platform_checking_writes_log(admin_client, caplog):
+@patch(
+    "accessibility_monitoring_platform.apps.common.middleware.validate_host_middleware.logger.info"
+)
+def test_platform_checking_writes_log(mock_logger, admin_client, caplog):
     """Test platform checking writes to log"""
     response: HttpResponse = admin_client.post(
         reverse("common:platform-checking"),

--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -45,7 +45,6 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "").split(" ")
-ALLOWED_HOSTS += [f"10.0.{i}.{j}" for i in range(256) for j in range(256)]
 
 CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 CSRF_TRUSTED_ORIGINS.append("http://localhost:3000")
@@ -96,6 +95,7 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_otp.middleware.OTPMiddleware",
+    "accessibility_monitoring_platform.apps.common.middleware.validate_host_middleware.ValidateHostMiddleware",
     "accessibility_monitoring_platform.apps.common.middleware.permissions_policy_middleware.PermissionsPolicyMiddleware",
     "accessibility_monitoring_platform.apps.common.middleware.cache_user_id_middleware.CacheUserUniqueID",
     "csp.middleware.CSPMiddleware",
@@ -196,7 +196,7 @@ LOGGING = {
     "loggers": {
         "": {
             "handlers": ["console"],
-            "level": "WARNING",
+            "level": "INFO",
         },
     },
 }

--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -45,6 +45,7 @@ SECRET_KEY = os.getenv("SECRET_KEY")
 
 
 ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "").split(" ")
+ALLOWED_HOSTS += [f"10.0.{i}.{j}" for i in range(256) for j in range(256)]
 
 CSRF_TRUSTED_ORIGINS = [f"https://{host}" for host in ALLOWED_HOSTS]
 CSRF_TRUSTED_ORIGINS.append("http://localhost:3000")

--- a/amp_platform.DockerFile
+++ b/amp_platform.DockerFile
@@ -15,4 +15,4 @@ CMD make static_files_process \
     && python manage.py collectstatic --noinput \
     && python manage.py migrate \
     && python manage.py recache_statuses \
-    && waitress-serve --port=8001 accessibility_monitoring_platform.wsgi:application
+    && waitress-serve --port=8001 --threads=10 accessibility_monitoring_platform.wsgi:application

--- a/amp_platform.DockerFile
+++ b/amp_platform.DockerFile
@@ -18,4 +18,4 @@ CMD make static_files_process \
     && python manage.py collectstatic --noinput \
     && python manage.py migrate \
     && python manage.py recache_statuses \
-    && waitress-serve --port=8001 accessibility_monitoring_platform.wsgi:application
+    && waitress-serve --port=8001 --threads=10 accessibility_monitoring_platform.wsgi:application

--- a/amp_platform.DockerFile
+++ b/amp_platform.DockerFile
@@ -18,4 +18,4 @@ CMD make static_files_process \
     && python manage.py collectstatic --noinput \
     && python manage.py migrate \
     && python manage.py recache_statuses \
-    && waitress-serve --port=8001 --threads=10 accessibility_monitoring_platform.wsgi:application
+    && waitress-serve --port=8001 accessibility_monitoring_platform.wsgi:application

--- a/amp_viewer.DockerFile
+++ b/amp_viewer.DockerFile
@@ -14,4 +14,4 @@ RUN npm install
 EXPOSE 8001
 CMD make static_files_process \
     && python manage_report_viewer.py collectstatic --noinput \
-    && waitress-serve --port=8001 report_viewer.wsgi:application
+    && waitress-serve --port=8001 --threads=10 report_viewer.wsgi:application

--- a/amp_viewer.DockerFile
+++ b/amp_viewer.DockerFile
@@ -11,4 +11,4 @@ RUN npm install
 EXPOSE 8001
 CMD make static_files_process \
     && python manage_report_viewer.py collectstatic --noinput \
-    && waitress-serve --port=8001 report_viewer.wsgi:application
+    && waitress-serve --port=8001 --threads=10 report_viewer.wsgi:application

--- a/amp_viewer.DockerFile
+++ b/amp_viewer.DockerFile
@@ -14,4 +14,4 @@ RUN npm install
 EXPOSE 8001
 CMD make static_files_process \
     && python manage_report_viewer.py collectstatic --noinput \
-    && waitress-serve --port=8001 --threads=10 report_viewer.wsgi:application
+    && waitress-serve --port=8001 report_viewer.wsgi:application

--- a/copilot/amp-svc/manifest.yml
+++ b/copilot/amp-svc/manifest.yml
@@ -54,7 +54,7 @@ variables:
   AWS_REGION: 'eu-west-2'
   DB_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-reportstorageBucketName
-  ALLOWED_HOSTS: '* *.accessibility-monitoring.service.gov.uk platform.accessibility-monitoring.service.gov.uk platform.aws.accessibility-monitoring.service.gov.uk'
+  ALLOWED_HOSTS: '.accessibility-monitoring.service.gov.uk'
 
 environments:
   prodenv:

--- a/copilot/viewer-svc/manifest.yml
+++ b/copilot/viewer-svc/manifest.yml
@@ -71,7 +71,7 @@ variables:
   AWS_REGION: 'eu-west-2'
   DB_NAME:
     from_cfn: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-reportstorageBucketName
-  ALLOWED_HOSTS: '* *.accessibility-monitoring.service.gov.uk reports.accessibility-monitoring.service.gov.uk reports.aws.accessibility-monitoring.service.gov.uk'
+  ALLOWED_HOSTS: '.accessibility-monitoring.service.gov.uk'
 
 environments:
   prodenv:


### PR DESCRIPTION
Copy of `1355-middleware` branch for use to deploy uniquely named prototype.

Trello card [#1355](https://trello.com/c/3lp76Xlh/1355-django-has-to-allow-all-hosts-on-copilot).