### PR TITLE
1378: Fix links to published reports in prototypes

### DIFF
--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -298,6 +298,7 @@ if os.path.isfile(aws_prototype_filename):
     AMP_PROTOTYPE_NAME = aws_prototype_data["prototype_name"]
     AMP_PROTOCOL: str = aws_prototype_data["amp_protocol"]
     AMP_VIEWER_DOMAIN: str = aws_prototype_data["viewer_domain"]
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 else:
     AMP_PROTOTYPE_NAME = os.getenv("AMP_PROTOTYPE_NAME", "")
     AMP_PROTOCOL = os.getenv("AMP_PROTOCOL", "http://")

--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -298,7 +298,6 @@ if os.path.isfile(aws_prototype_filename):
     AMP_PROTOTYPE_NAME = aws_prototype_data["prototype_name"]
     AMP_PROTOCOL: str = aws_prototype_data["amp_protocol"]
     AMP_VIEWER_DOMAIN: str = aws_prototype_data["viewer_domain"]
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 else:
     AMP_PROTOTYPE_NAME = os.getenv("AMP_PROTOTYPE_NAME", "")
     AMP_PROTOCOL = os.getenv("AMP_PROTOCOL", "http://")

--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -291,16 +291,17 @@ CSP_SCRIPT_SRC = ("'self'",)
 CSP_FONT_SRC = ("'self'",)
 CSP_IMG_SRC = ("'self'", "data:")
 
-AMP_PROTOCOL = os.getenv("AMP_PROTOCOL", "http://")
-AMP_VIEWER_DOMAIN = os.getenv("AMP_VIEWER_DOMAIN", "localhost:8002")
-
-aws_prototype_filename: str = "aws_prototype_name.txt"
+aws_prototype_filename: str = "aws_prototype.json"
 if os.path.isfile(aws_prototype_filename):
-    aws_prototype_name_file = open(aws_prototype_filename, "r")
-    aws_prototype_name: str = aws_prototype_name_file.read()
-    AMP_PROTOTYPE_NAME = aws_prototype_name.strip()
+    aws_prototype_file = open(aws_prototype_filename, "r")
+    aws_prototype_data: str = json.load(aws_prototype_file)
+    AMP_PROTOTYPE_NAME = aws_prototype_data["prototype_name"]
+    AMP_PROTOCOL: str = aws_prototype_data["amp_protocol"]
+    AMP_VIEWER_DOMAIN: str = aws_prototype_data["viewer_domain"]
 else:
     AMP_PROTOTYPE_NAME = os.getenv("AMP_PROTOTYPE_NAME", "")
+    AMP_PROTOCOL = os.getenv("AMP_PROTOCOL", "http://")
+    AMP_VIEWER_DOMAIN = os.getenv("AMP_VIEWER_DOMAIN", "localhost:8002")
 
 COPILOT_APPLICATION_NAME = os.getenv("COPILOT_APPLICATION_NAME", None)
 

--- a/accessibility_monitoring_platform/settings/deploy.py
+++ b/accessibility_monitoring_platform/settings/deploy.py
@@ -21,7 +21,10 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-if os.getenv("NOTIFY_API_KEY"):
+aws_prototype_filename: str = "aws_prototype.json"
+if os.path.isfile(aws_prototype_filename):
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+elif os.getenv("NOTIFY_API_KEY"):
     EMAIL_BACKEND = "accessibility_monitoring_platform.email.NotifyEmailBackend"
     EMAIL_NOTIFY_API_KEY = os.getenv("NOTIFY_API_KEY")
     EMAIL_NOTIFY_BASIC_TEMPLATE = os.getenv("EMAIL_NOTIFY_BASIC_TEMPLATE")

--- a/aws_prototype/main.py
+++ b/aws_prototype/main.py
@@ -1,5 +1,6 @@
 """main - main function for deploy feature to AWS Copilot"""
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -214,18 +215,27 @@ def down():
     restore_copilot_prod_settings()
 
 
-def write_prototype_name():
+def write_prototype_file():
     """
-    Write git branch name to file for use in prototype watermark in UI
+    Write prototype details to file for use in platform
     """
-    aws_prototype_filename: str = "aws_prototype_name.txt"
-    aws_prototype_file = open(aws_prototype_filename, "w")
-    aws_prototype_file.write(git_branch_name)
-    aws_prototype_file.close()
+    aws_prototype_filename: str = "aws_prototype.json"
+    with open(aws_prototype_filename, "w") as aws_prototype_file:
+        aws_prototype_file.write(
+            json.dumps(
+                {
+                    "prototype_name": git_branch_name,
+                    "amp_protocol": "https://",
+                    "viewer_domain": f"viewer-svc.env{prototype_name}.app{prototype_name}"
+                    ".proto.accessibility-monitoring.service.gov.uk",
+                },
+                indent=4,
+            )
+        )
 
 
 if __name__ == "__main__":
-    write_prototype_name()
+    write_prototype_file()
     client = boto3.client("sts")
     account_id = client.get_caller_identity()["Account"]
     if account_id != AWS_ACCOUNT_ID:

--- a/aws_prototype/main.py
+++ b/aws_prototype/main.py
@@ -1,17 +1,18 @@
 """main - main function for deploy feature to AWS Copilot"""
 import argparse
-import json
 import os
 import shutil
 import subprocess
-import random
-import string
 from typing import List
 
 import boto3
 from django.core.management.utils import get_random_secret_key
 
-from utils import get_aws_resource_tags, write_prototype_platform_metadata
+from utils import (
+    get_aws_resource_tags,
+    write_prototype_platform_metadata,
+    create_burner_account,
+)
 
 parser = argparse.ArgumentParser(description="Deploy feature branch to AWS")
 
@@ -120,23 +121,6 @@ def restore_prototype_env_file() -> None:
     )
 
 
-def create_burner_account() -> None:
-    print(">>> Creating burner account")
-    email: str = f"""{"".join(random.choice(string.ascii_lowercase) for x in range(7))}@email.com"""
-    password: str = "".join(random.choice(string.ascii_lowercase) for x in range(27))
-    command: str = f"python aws_prototype/create_dummy_account.py {email} {password}"
-    copilot_exec_cmd = f"""copilot svc exec -a {APP_NAME} -e {ENV_NAME} -n amp-svc --command "{command}" """
-    os.system(copilot_exec_cmd)
-    print(
-        f"The platform can be accessed from https://amp-svc.{ENV_NAME}.{APP_NAME}.proto.accessibility-monitoring.service.gov.uk"
-    )
-    print(
-        f"The viewer can be accessed from https://viewer-svc.{ENV_NAME}.{APP_NAME}.proto.accessibility-monitoring.service.gov.uk"
-    )
-    print(f"email: {email}")
-    print(f"password: {password}")
-
-
 def up():
     print(">>> Setting up AWS Copilot prototype")
 
@@ -235,6 +219,6 @@ if __name__ == "__main__":
     elif args.build_direction == "down":
         down()
     elif args.build_direction == "newaccount":
-        create_burner_account()
+        create_burner_account(app_name=APP_NAME, env_name=ENV_NAME)
     else:
         raise Exception("Build direction needs to be up or down or newaccount")

--- a/aws_prototype/main.py
+++ b/aws_prototype/main.py
@@ -11,7 +11,7 @@ from typing import List
 import boto3
 from django.core.management.utils import get_random_secret_key
 
-from utils import get_aws_resource_tags
+from utils import get_aws_resource_tags, write_prototype_platform_metadata
 
 parser = argparse.ArgumentParser(description="Deploy feature branch to AWS")
 
@@ -215,27 +215,10 @@ def down():
     restore_copilot_prod_settings()
 
 
-def write_prototype_file():
-    """
-    Write prototype details to file for use in platform
-    """
-    aws_prototype_filename: str = "aws_prototype.json"
-    with open(aws_prototype_filename, "w") as aws_prototype_file:
-        aws_prototype_file.write(
-            json.dumps(
-                {
-                    "prototype_name": git_branch_name,
-                    "amp_protocol": "https://",
-                    "viewer_domain": f"viewer-svc.env{prototype_name}.app{prototype_name}"
-                    ".proto.accessibility-monitoring.service.gov.uk",
-                },
-                indent=4,
-            )
-        )
-
-
 if __name__ == "__main__":
-    write_prototype_file()
+    write_prototype_platform_metadata(
+        git_branch_name=git_branch_name, prototype_name=prototype_name
+    )
     client = boto3.client("sts")
     account_id = client.get_caller_identity()["Account"]
     if account_id != AWS_ACCOUNT_ID:

--- a/aws_prototype/main.py
+++ b/aws_prototype/main.py
@@ -123,7 +123,7 @@ def restore_prototype_env_file() -> None:
 def create_burner_account() -> None:
     print(">>> Creating burner account")
     email: str = f"""{"".join(random.choice(string.ascii_lowercase) for x in range(7))}@email.com"""
-    password: str = "".join(random.choice(string.ascii_lowercase) for x in range(7))
+    password: str = "".join(random.choice(string.ascii_lowercase) for x in range(27))
     command: str = f"python aws_prototype/create_dummy_account.py {email} {password}"
     copilot_exec_cmd = f"""copilot svc exec -a {APP_NAME} -e {ENV_NAME} -n amp-svc --command "{command}" """
     os.system(copilot_exec_cmd)

--- a/aws_prototype/tests/test_utils.py
+++ b/aws_prototype/tests/test_utils.py
@@ -2,12 +2,17 @@
 Test aws prototype utilities
 """
 import pytest
+from unittest.mock import patch, mock_open
 
-from ..utils import get_aws_resource_tags
+from ..utils import get_aws_resource_tags, write_prototype_platform_metadata
+
+GIT_BRANCH_NAME: str = "0001-branch-name"
+PROTOTYPE_NAME: str = "0001r"
 
 
 @pytest.mark.parametrize("system", ["Platform", "Viewer"])
 def test_get_aws_resource_tags(system):
+    """Test expected tags are added to AWS objects"""
     assert (
         get_aws_resource_tags(system=system)
         == "--resource-tags Product=Accessibility-Monitoring-Platform,"
@@ -15,3 +20,20 @@ def test_get_aws_resource_tags(system):
         "Owner=a11y-monitoring-cicd-mgmt@digital.cabinet-office.gov.uk,"
         "Source=https://github.com/alphagov/accessibility-monitoring-platform"
     )
+
+
+def test_write_prototype_platform_metadata():
+    """Test expected metadata for platform settings is written for prototypes"""
+    with patch("aws_prototype.utils.open", mock_open()) as mock_file:
+        write_prototype_platform_metadata(
+            git_branch_name=GIT_BRANCH_NAME, prototype_name=PROTOTYPE_NAME
+        )
+
+        mock_file.assert_called_once_with("aws_prototype.json", "w")
+        mock_file().write.assert_called_once_with(
+            "{\n    "
+            f'"prototype_name": "{GIT_BRANCH_NAME}",'
+            '\n    "amp_protocol": "https://",\n    '
+            f'"viewer_domain": "viewer-svc.env{PROTOTYPE_NAME}.app{PROTOTYPE_NAME}'
+            '.proto.accessibility-monitoring.service.gov.uk"\n}'
+        )

--- a/aws_prototype/utils.py
+++ b/aws_prototype/utils.py
@@ -2,6 +2,9 @@
 Utilities for aws prototype
 """
 import json
+import os
+import random
+import string
 from typing import Dict, List, Tuple
 
 AWS_RESOURCE_TAGS = {
@@ -40,3 +43,20 @@ def write_prototype_platform_metadata(git_branch_name: str, prototype_name: str)
                 indent=4,
             )
         )
+
+
+def create_burner_account(app_name: str, env_name: str) -> None:
+    print(">>> Creating burner account")
+    email: str = f"""{"".join(random.choice(string.ascii_lowercase) for x in range(7))}@email.com"""
+    password: str = "".join(random.choice(string.ascii_lowercase) for x in range(27))
+    command: str = f"python aws_prototype/create_dummy_account.py {email} {password}"
+    copilot_exec_cmd = f"""copilot svc exec -a {app_name} -e {env_name} -n amp-svc --command "{command}" """
+    os.system(copilot_exec_cmd)
+    print(
+        f"The platform can be accessed from https://amp-svc.{env_name}.{app_name}.proto.accessibility-monitoring.service.gov.uk"
+    )
+    print(
+        f"The viewer can be accessed from https://viewer-svc.{env_name}.{app_name}.proto.accessibility-monitoring.service.gov.uk"
+    )
+    print(f"email: {email}")
+    print(f"password: {password}")

--- a/aws_prototype/utils.py
+++ b/aws_prototype/utils.py
@@ -1,6 +1,7 @@
 """
 Utilities for aws prototype
 """
+import json
 from typing import Dict, List, Tuple
 
 AWS_RESOURCE_TAGS = {
@@ -20,3 +21,22 @@ def get_aws_resource_tags(system: str = "Platform") -> str:
         f"{key}={value}" for key, value in resource_tags.items()
     ]
     return f"--resource-tags {','.join(tag_name_value_pairs)}"
+
+
+def write_prototype_platform_metadata(git_branch_name: str, prototype_name: str):
+    """
+    Write prototype metadata to json file for use in platform settings
+    """
+    aws_prototype_filename: str = "aws_prototype.json"
+    with open(aws_prototype_filename, "w") as aws_prototype_file:
+        aws_prototype_file.write(
+            json.dumps(
+                {
+                    "prototype_name": git_branch_name,
+                    "amp_protocol": "https://",
+                    "viewer_domain": f"viewer-svc.env{prototype_name}.app{prototype_name}"
+                    ".proto.accessibility-monitoring.service.gov.uk",
+                },
+                indent=4,
+            )
+        )

--- a/report_viewer/settings/base.py
+++ b/report_viewer/settings/base.py
@@ -272,8 +272,3 @@ CSP_STYLE_SRC = "'self'"
 CSP_SCRIPT_SRC = ("'self'",)
 CSP_FONT_SRC = ("'self'",)
 CSP_IMG_SRC = ("'self'", "data:")
-
-
-aws_prototype_filename: str = "aws_prototype.json"
-if os.path.isfile(aws_prototype_filename):
-    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/report_viewer/settings/base.py
+++ b/report_viewer/settings/base.py
@@ -272,3 +272,8 @@ CSP_STYLE_SRC = "'self'"
 CSP_SCRIPT_SRC = ("'self'",)
 CSP_FONT_SRC = ("'self'",)
 CSP_IMG_SRC = ("'self'", "data:")
+
+
+aws_prototype_filename: str = "aws_prototype.json"
+if os.path.isfile(aws_prototype_filename):
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"

--- a/report_viewer/settings/deploy.py
+++ b/report_viewer/settings/deploy.py
@@ -20,8 +20,10 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-
-if os.getenv("NOTIFY_API_KEY"):
+aws_prototype_filename: str = "aws_prototype.json"
+if os.path.isfile(aws_prototype_filename):
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+elif os.getenv("NOTIFY_API_KEY"):
     EMAIL_BACKEND = "accessibility_monitoring_platform.email.NotifyEmailBackend"
     EMAIL_NOTIFY_API_KEY = os.getenv("NOTIFY_API_KEY")
     EMAIL_NOTIFY_BASIC_TEMPLATE = os.getenv("EMAIL_NOTIFY_BASIC_TEMPLATE")


### PR DESCRIPTION
Trello cards:

* [#1378](https://trello.com/c/6KWdtLEn/1378-fix-links-to-published-report-in-prototypes) Fix links to published reports in prototypes
* [#1372](https://trello.com/c/kjusICTS/1372-add-local-email-server-to-prototypes) Use console email backend in prototypes.
* [#1377](https://trello.com/c/pcoYpa20/1377-make-prototype-temporary-passwords-longer) Make temporary passwords longer in prototypes.