### PR TITLE
1388: Add 'to report' to followup labels

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -355,8 +355,12 @@ class CaseReportCorrespondenceUpdateForm(VersionForm):
     report_sent_date = AMPDateField(
         label="Report sent on", help_text="This field affects the case status"
     )
-    report_followup_week_1_sent_date = AMPDateSentField(label="1-week followup date")
-    report_followup_week_4_sent_date = AMPDateSentField(label="4-week followup date")
+    report_followup_week_1_sent_date = AMPDateSentField(
+        label="1-week followup to report date"
+    )
+    report_followup_week_4_sent_date = AMPDateSentField(
+        label="4-week followup to report date"
+    )
     report_acknowledged_date = AMPDateField(
         label="Report acknowledged", help_text="This field affects the case status"
     )
@@ -384,8 +388,8 @@ class CaseReportFollowupDueDatesUpdateForm(VersionForm):
     Form for updating report followup due dates
     """
 
-    report_followup_week_1_due_date = AMPDateField(label="1-week followup")
-    report_followup_week_4_due_date = AMPDateField(label="4-week followup")
+    report_followup_week_1_due_date = AMPDateField(label="1-week followup to report")
+    report_followup_week_4_due_date = AMPDateField(label="4-week followup to report")
     report_followup_week_12_due_date = AMPDateField(label="12-week deadline")
 
     class Meta:

--- a/accessibility_monitoring_platform/apps/cases/models.py
+++ b/accessibility_monitoring_platform/apps/cases/models.py
@@ -675,37 +675,37 @@ class Case(VersionModel):
             and self.report_followup_week_1_due_date > now
             and self.report_followup_week_1_sent_date is None
         ):
-            return "1-week followup coming up"
+            return "1-week followup to report coming up"
         elif (
             self.report_followup_week_1_due_date
             and self.report_followup_week_1_due_date <= now
             and self.report_followup_week_1_sent_date is None
         ):
-            return "1-week followup due"
+            return "1-week followup to report due"
         elif (
             self.report_followup_week_1_sent_date
             and self.report_followup_week_4_due_date
             and self.report_followup_week_4_due_date > now
             and self.report_followup_week_4_sent_date is None
         ):
-            return "4-week followup coming up"
+            return "4-week followup to report coming up"
         elif (
             self.report_followup_week_1_sent_date
             and self.report_followup_week_4_due_date
             and self.report_followup_week_4_due_date <= now
             and self.report_followup_week_4_sent_date is None
         ):
-            return "4-week followup due"
+            return "4-week followup to report due"
         elif (
             self.report_followup_week_4_sent_date is not None
             and self.report_followup_week_4_sent_date > seven_days_ago
         ):
-            return "4-week followup sent, waiting five days for response"
+            return "4-week followup to report sent, waiting five days for response"
         elif (
             self.report_followup_week_4_sent_date is not None
             and self.report_followup_week_4_sent_date <= seven_days_ago
         ):
-            return "4-week followup sent, case needs to progress"
+            return "4-week followup to report sent, case needs to progress"
         return "Unknown"
 
     @property

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/report_correspondence.html
@@ -55,19 +55,19 @@
             </td>
         </tr>
         <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">1-week followup due</th>
+            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">1-week followup to report due</th>
             <td class="govuk-table__cell amp-width-one-half">{{ case.report_followup_week_1_due_date|amp_date }}</td>
         </tr>
         <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">1-week followup sent</th>
+            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">1-week followup to report sent</th>
             <td class="govuk-table__cell amp-width-one-half">{{ case.report_followup_week_1_sent_date|amp_date }}</td>
         </tr>
         <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">4-week followup due</th>
+            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">4-week followup to report due</th>
             <td class="govuk-table__cell amp-width-one-half">{{ case.report_followup_week_4_due_date|amp_date }}</td>
         </tr>
         <tr class="govuk-table__row">
-            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">4-week followup sent</th>
+            <th scope="row" class="govuk-table__cell amp-font-weight-normal amp-width-one-half">4-week followup to report sent</th>
             <td class="govuk-table__cell amp-width-one-half">{{ case.report_followup_week_4_sent_date|amp_date }}</td>
         </tr>
         <tr class="govuk-table__row">

--- a/accessibility_monitoring_platform/apps/overdue/tests.py
+++ b/accessibility_monitoring_platform/apps/overdue/tests.py
@@ -129,7 +129,7 @@ def test_in_report_correspondence_week_1_overdue():
 
     assert len(Case.objects.all()) == 2
     assert len(get_overdue_cases(user)) == 1
-    assert case.in_report_correspondence_progress == "1-week followup due"
+    assert case.in_report_correspondence_progress == "1-week followup to report due"
 
 
 @pytest.mark.django_db
@@ -146,7 +146,7 @@ def test_in_report_correspondence_week_4_overdue():
 
     assert len(Case.objects.all()) == 2
     assert len(get_overdue_cases(user)) == 1
-    assert case.in_report_correspondence_progress == "4-week followup due"
+    assert case.in_report_correspondence_progress == "4-week followup to report due"
 
 
 @pytest.mark.django_db
@@ -166,7 +166,7 @@ def test_in_report_correspondence_psb_overdue_after_four_week_reminder():
     assert len(get_overdue_cases(user)) == 1
     assert (
         case.in_report_correspondence_progress
-        == "4-week followup sent, case needs to progress"
+        == "4-week followup to report sent, case needs to progress"
     )
 
 

--- a/stack_tests/integration_tests/cypress/e2e/case.cy.js
+++ b/stack_tests/integration_tests/cypress/e2e/case.cy.js
@@ -15,17 +15,17 @@ const psbAppealNote = 'PSB appeal note'
 
 describe('View case', () => {
   beforeEach(() => {
-    cy.session('login', cy.login, {cacheAcrossSpecs: true})
+    cy.session('login', cy.login, { cacheAcrossSpecs: true })
     cy.visit('/cases/1/view')
   })
 
   it('can search within case', () => {
     cy.get('[name="search_in_case"]').clear().type('report sent')
     cy.get('#search-in-case').click()
-    cy.contains('Found 1 result for report sent')
+    cy.contains('Found 3 results for report sent')
     cy.contains('Report sent')
     cy.get('#clear-search-in-case').click()
-    cy.contains('Found 1 result for report sent').should('not.exist')
+    cy.contains('Found 3 results for report sent').should('not.exist')
   })
 
   it('can edit case details', () => {


### PR DESCRIPTION
Trello card [#1388](https://trello.com/c/Dg0MEJkp/1388-make-labels-clearer-in-the-correspondence-page).