### PR TITLE
1293: Add placeholder text to email templates when no WCAG issues

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
@@ -59,34 +59,38 @@
                     Please review the issues listed below and provide an update.
                     <br>
                     <br>
-                    {% for issues_table in issues_tables %}
-                        {% if issues_table.rows %}
-                            <h2>{{ issues_table.page }}{% if issues_table.page.page_type != 'pdf' %} page{% endif %} issues</h2>
-                            <a href="{{ issues_table.page.url }}">{{ issues_table.page.url }}</a>
-                            <br>
-                            <br>
-                            <table id="email-issues-table-{{ forloop.counter }}">
-                                <thead>
-                                    <tr>
-                                        <th width=1%>#</th>
-                                        <th id="issue-{{ forloop.counter }}" width=33%>Issue and description</th>
-                                        <th id="where-found-{{ forloop.counter }}" width=33%>Where the issue was found</th>
-                                        <th id="12-week-update-{{ forloop.counter }}" width=33%>Organisation 12-week update</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for row in issues_table.rows %}
-                                        <tr valign="top">
-                                            <td width=1%>{{ forloop.counter }}</td>
-                                            <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_1|markdown_to_html }}</td>
-                                            <td headers="where-found-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_2|markdown_to_html }}</td>
-                                            <td headers="12-week-update-{{ forloop.parentloop.counter }}" width=33%></td>
+                    {% if case.audit.unfixed_check_results %}
+                        {% for issues_table in issues_tables %}
+                            {% if issues_table.rows %}
+                                <h2>{{ issues_table.page }}{% if issues_table.page.page_type != 'pdf' %} page{% endif %} issues</h2>
+                                <a href="{{ issues_table.page.url }}">{{ issues_table.page.url }}</a>
+                                <br>
+                                <br>
+                                <table id="email-issues-table-{{ forloop.counter }}">
+                                    <thead>
+                                        <tr>
+                                            <th width=1%>#</th>
+                                            <th id="issue-{{ forloop.counter }}" width=33%>Issue and description</th>
+                                            <th id="where-found-{{ forloop.counter }}" width=33%>Where the issue was found</th>
+                                            <th id="12-week-update-{{ forloop.counter }}" width=33%>Organisation 12-week update</th>
                                         </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        {% endif %}
-                    {% endfor %}
+                                    </thead>
+                                    <tbody>
+                                        {% for row in issues_table.rows %}
+                                            <tr valign="top">
+                                                <td width=1%>{{ forloop.counter }}</td>
+                                                <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_1|markdown_to_html }}</td>
+                                                <td headers="where-found-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_2|markdown_to_html }}</td>
+                                                <td headers="12-week-update-{{ forloop.parentloop.counter }}" width=33%></td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% endif %}
+                        {% endfor %}
+                    {% else %}
+                        No accessibilty issues found.
+                    {% endif %}
                     <h2>Your statement</h2>
                     {{ case.audit.get_accessibility_statement_state_display }}
                     {% if case.audit.accessibility_statement_state == 'found-but' %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
@@ -89,7 +89,7 @@
                             {% endif %}
                         {% endfor %}
                     {% else %}
-                        No accessibilty issues found.
+                        No accessibility issues found.
                     {% endif %}
                     <h2>Your statement</h2>
                     {{ case.audit.get_accessibility_statement_state_display }}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
@@ -89,7 +89,7 @@
                             {% endif %}
                         {% endfor %}
                     {% else %}
-                        No accessibility issues found.
+                        We found no major issues.
                     {% endif %}
                     <h2>Your statement</h2>
                     {{ case.audit.get_accessibility_statement_state_display }}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/twelve_week_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/twelve_week_correspondence.html
@@ -122,7 +122,7 @@
                             {% endif %}
                         {% endfor %}
                     {% else %}
-                        No accessibility issues found.
+                        We found no major issues.
                     {% endif %}
                     <h2>Accessibility statement comments</h2>
                     {% if case.audit.uses_statement_checks %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/twelve_week_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/twelve_week_correspondence.html
@@ -91,11 +91,11 @@
                     You do not need to provide information from your own audit.
                     <br>
                     <br>
-                    Please provide these by filling in the last column of the below tables
-                    and provide an update on the Accessibility statement.
-                    <br>
-                    <br>
                     {% if case.audit.unfixed_check_results %}
+                        Please provide these by filling in the last column of the below tables
+                        and provide an update on the Accessibility statement.
+                        <br>
+                        <br>
                         {% for issues_table in issues_tables %}
                             {% if issues_table.rows %}
                                 <h2>{{ issues_table.page }}{% if issues_table.page.page_type != 'pdf' %} page{% endif %} issues</h2>
@@ -122,7 +122,7 @@
                             {% endif %}
                         {% endfor %}
                     {% else %}
-                        No accessibilty issues found.
+                        No accessibility issues found.
                     {% endif %}
                     <h2>Accessibility statement comments</h2>
                     {% if case.audit.uses_statement_checks %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/twelve_week_correspondence.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/twelve_week_correspondence.html
@@ -95,31 +95,35 @@
                     and provide an update on the Accessibility statement.
                     <br>
                     <br>
-                    {% for issues_table in issues_tables %}
-                        {% if issues_table.rows %}
-                            <h2>{{ issues_table.page }}{% if issues_table.page.page_type != 'pdf' %} page{% endif %} issues</h2>
-                            <table id="email-issues-table-{{ forloop.counter }}">
-                                <thead>
-                                    <tr>
-                                        <th width=1%>#</th>
-                                        <th id="issue-{{ forloop.counter }}" width=33%>Issue and description</th>
-                                        <th id="where-found-{{ forloop.counter }}" width=33%>Where the issue was found</th>
-                                        <th id="12-week-update-{{ forloop.counter }}" width=33%>12-week update</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    {% for row in issues_table.rows %}
-                                        <tr valign="top">
-                                            <td width=1%>{{ forloop.counter }}</td>
-                                            <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_1|markdown_to_html }}</td>
-                                            <td headers="where-found-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_2|markdown_to_html }}</td>
-                                            <td headers="12-week-update-{{ forloop.parentloop.counter }}" width=33%></td>
+                    {% if case.audit.unfixed_check_results %}
+                        {% for issues_table in issues_tables %}
+                            {% if issues_table.rows %}
+                                <h2>{{ issues_table.page }}{% if issues_table.page.page_type != 'pdf' %} page{% endif %} issues</h2>
+                                <table id="email-issues-table-{{ forloop.counter }}">
+                                    <thead>
+                                        <tr>
+                                            <th width=1%>#</th>
+                                            <th id="issue-{{ forloop.counter }}" width=33%>Issue and description</th>
+                                            <th id="where-found-{{ forloop.counter }}" width=33%>Where the issue was found</th>
+                                            <th id="12-week-update-{{ forloop.counter }}" width=33%>12-week update</th>
                                         </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        {% endif %}
-                    {% endfor %}
+                                    </thead>
+                                    <tbody>
+                                        {% for row in issues_table.rows %}
+                                            <tr valign="top">
+                                                <td width=1%>{{ forloop.counter }}</td>
+                                                <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_1|markdown_to_html }}</td>
+                                                <td headers="where-found-{{ forloop.parentloop.counter }}" width=33%>{{ row.cell_content_2|markdown_to_html }}</td>
+                                                <td headers="12-week-update-{{ forloop.parentloop.counter }}" width=33%></td>
+                                            </tr>
+                                        {% endfor %}
+                                    </tbody>
+                                </table>
+                            {% endif %}
+                        {% endfor %}
+                    {% else %}
+                        No accessibilty issues found.
+                    {% endif %}
                     <h2>Accessibility statement comments</h2>
                     {% if case.audit.uses_statement_checks %}
                         {% if case.audit.failed_statement_check_results %}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -3521,7 +3521,7 @@ def test_twelve_week_email_template_contains_no_issues(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "No accessibilty issues found.")
+    assertContains(response, "No accessibility issues found.")
 
 
 def test_outstanding_issues_email_template_contains_issues(admin_client):
@@ -3566,4 +3566,4 @@ def test_outstanding_issues_email_template_contains_no_issues(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "No accessibilty issues found.")
+    assertContains(response, "No accessibility issues found.")

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -3521,7 +3521,7 @@ def test_twelve_week_email_template_contains_no_issues(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "No accessibility issues found.")
+    assertContains(response, "We found no major issues.")
 
 
 def test_outstanding_issues_email_template_contains_issues(admin_client):
@@ -3566,4 +3566,4 @@ def test_outstanding_issues_email_template_contains_no_issues(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "No accessibility issues found.")
+    assertContains(response, "We found no major issues.")

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -3507,6 +3507,23 @@ def test_twelve_week_email_template_contains_issues(admin_client):
     assertContains(response, ERROR_NOTES)
 
 
+def test_twelve_week_email_template_contains_no_issues(admin_client):
+    """
+    Test twelve week email template with no issues contains placeholder text.
+    """
+    case: Case = Case.objects.create()
+    audit: Audit = Audit.objects.create(case=case)
+    url: str = reverse(
+        "cases:twelve-week-correspondence-email", kwargs={"pk": audit.case.id}
+    )
+
+    response: HttpResponse = admin_client.get(url)
+
+    assert response.status_code == 200
+
+    assertContains(response, "No accessibilty issues found.")
+
+
 def test_outstanding_issues_email_template_contains_issues(admin_client):
     """
     Test outstanding issues email template contains only unfixed issues.
@@ -3535,3 +3552,18 @@ def test_outstanding_issues_email_template_contains_issues(admin_client):
     assert response.status_code == 200
 
     assertNotContains(response, ERROR_NOTES)
+
+
+def test_outstanding_issues_email_template_contains_no_issues(admin_client):
+    """
+    Test outstanding issues email template with no issues contains placeholder text.
+    """
+    case: Case = Case.objects.create()
+    audit: Audit = Audit.objects.create(case=case)
+    url: str = reverse("cases:outstanding-issues-email", kwargs={"pk": audit.case.id})
+
+    response: HttpResponse = admin_client.get(url)
+
+    assert response.status_code == 200
+
+    assertContains(response, "No accessibilty issues found.")


### PR DESCRIPTION
Trello card [#1293](https://trello.com/c/wsHrblAT/1293-include-no-wcag-errors-found-on-the-website-in-the-email-templates-when-there-are-no-errors-found).