### PR TITLE
1416: Exclude missing pages from policy metrics

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/admin.py
+++ b/accessibility_monitoring_platform/apps/audits/admin.py
@@ -25,7 +25,7 @@ class AuditAdmin(admin.ModelAdmin):
 class PageAdmin(admin.ModelAdmin):
     """Django admin configuration for Page model"""
 
-    search_fields = ["name", "url", "audit__case_organisation_name"]
+    search_fields = ["name", "url", "audit__case__organisation_name"]
     list_display = ["page_type", "audit", "name", "url"]
     list_filter = ["page_type"]
 

--- a/accessibility_monitoring_platform/apps/common/metrics.py
+++ b/accessibility_monitoring_platform/apps/common/metrics.py
@@ -358,7 +358,9 @@ def get_policy_progress_metrics() -> List[ProgressMetric]:
     )
     compliant_audits_count: int = compliant_audits.count()
     check_results_of_last_90_days: QuerySet[CheckResult] = CheckResult.objects.filter(
-        audit__retest_date__gte=start_date
+        audit__retest_date__gte=start_date,
+        page__retest_page_missing_date=None,
+        page__is_deleted=False,
     )
     fixed_check_results_count: int = (
         check_results_of_last_90_days.filter(check_result_state="error")


### PR DESCRIPTION
Trello card [#1416](https://trello.com/c/hXkjL4V2/1416-remove-initial-wcag-issues-from-stats-when-the-page-is-missing-in-the-12-week-retest).