### PR TITLE
v0.6.27 - Use new case details fields; Show website name all over the UI

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -140,6 +140,11 @@ class CaseCreateForm(forms.ModelForm):
             attrs={"label": "Did this case originate from a complaint?"}
         ),
     )
+    parental_organisation_name = AMPCharFieldWide(label="Parental organisation name")
+    website_name = AMPCharFieldWide(label="Website name")
+    subcategory = AMPModelChoiceField(
+        label="Sub-category", queryset=SubCategory.objects.all()
+    )
 
     class Meta:
         model = Case
@@ -151,6 +156,9 @@ class CaseCreateForm(forms.ModelForm):
             "sector",
             "previous_case_url",
             "is_complaint",
+            "parental_organisation_name",
+            "website_name",
+            "subcategory",
         ]
 
     def clean_home_page_url(self):
@@ -180,12 +188,6 @@ class CaseDetailUpdateForm(CaseCreateForm, VersionForm):
     )
     trello_url = AMPURLField(label="Trello ticket URL")
     notes = AMPTextField(label="Notes")
-
-    parental_organisation_name = AMPCharFieldWide(label="Parental organisation name")
-    website_name = AMPCharFieldWide(label="Website name")
-    subcategory = AMPModelChoiceField(
-        label="Sub-category", queryset=SubCategory.objects.all()
-    )
     case_details_complete_date = AMPDatePageCompleteField()
 
     def __init__(self, *args, **kwargs):

--- a/accessibility_monitoring_platform/apps/cases/models.py
+++ b/accessibility_monitoring_platform/apps/cases/models.py
@@ -495,9 +495,13 @@ class Case(VersionModel):
 
     @property
     def title(self) -> str:
-        return str(
+        title: str = ""
+        if self.website_name:
+            title += f"{self.website_name} | "
+        title += (
             f"{self.organisation_name} | {self.formatted_home_page_url} | #{self.id}"
         )
+        return title
 
     @property
     def next_action_due_date(self) -> Optional[date]:

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/case_list.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/case_list.html
@@ -116,6 +116,7 @@
                                             <p class="govuk-body-l amp-margin-bottom-0">
                                                 <a href="{{ case.get_absolute_url }}"
                                                     class="govuk-link govuk-link--no-visited-state">
+                                                    {% if case.website_name %}{{ case.website_name }} |{% endif %}
                                                     {{ case.organisation_name }}
                                                 </a>
                                             </p>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/create.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/create.html
@@ -107,6 +107,21 @@
                             {% include 'common/amp_field.html' with field=form.is_complaint %}
                         </div>
                     </div>
+                    <div class="govuk-grid-row{% if duplicate_cases %} amp-display-none{% endif %}">
+                        <div class="govuk-grid-column-full">
+                            {% include 'common/amp_field.html' with field=form.parental_organisation_name %}
+                        </div>
+                    </div>
+                    <div class="govuk-grid-row{% if duplicate_cases %} amp-display-none{% endif %}">
+                        <div class="govuk-grid-column-full">
+                            {% include 'common/amp_field.html' with field=form.website_name %}
+                        </div>
+                    </div>
+                    <div class="govuk-grid-row{% if duplicate_cases %} amp-display-none{% endif %}">
+                        <div class="govuk-grid-column-full">
+                            {% include 'common/amp_field.html' with field=form.subcategory %}
+                        </div>
+                    </div>
 
                     {% if duplicate_cases %}
                         <h2 id="case-details" class="govuk-heading-m">Do you wish to continue?</h2>

--- a/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
@@ -360,6 +360,9 @@ def test_download_feedback_survey_cases():
         CONTACT_NOTES,
         "No",
         "",
+        "",
+        "",
+        "",
     ]
 
     validate_csv_response(
@@ -425,6 +428,9 @@ def test_download_equality_body_cases():
         "",
         "No",
         "n/a",
+        "",
+        "",
+        "",
         "No claim",
         "",
         "No claim",
@@ -553,6 +559,9 @@ def test_download_cases():
         "Contact for CSV export",
         "",
         "n/a",
+        "",
+        "",
+        "",
         "test@example.com",
     ]
 

--- a/accessibility_monitoring_platform/apps/cases/utils.py
+++ b/accessibility_monitoring_platform/apps/cases/utils.py
@@ -119,6 +119,12 @@ COLUMNS_FOR_EQUALITY_BODY: List[ColumnAndFieldNames] = [
         column_name="% of issues fixed",
         field_name="percentage_website_issues_fixed",
     ),
+    ColumnAndFieldNames(
+        column_name="Parental organisation name",
+        field_name="parental_organisation_name",
+    ),
+    ColumnAndFieldNames(column_name="Website name", field_name="website_name"),
+    ColumnAndFieldNames(column_name="Sub-category", field_name="subcategory"),
 ]
 
 EXTRA_AUDIT_COLUMNS_FOR_EQUALITY_BODY: List[ColumnAndFieldNames] = [
@@ -409,6 +415,12 @@ CASE_COLUMNS_FOR_EXPORT: List[ColumnAndFieldNames] = [
         column_name="% of issues fixed",
         field_name="percentage_website_issues_fixed",
     ),
+    ColumnAndFieldNames(
+        column_name="Parental organisation name",
+        field_name="parental_organisation_name",
+    ),
+    ColumnAndFieldNames(column_name="Website name", field_name="website_name"),
+    ColumnAndFieldNames(column_name="Sub-category", field_name="subcategory"),
 ]
 CONTACT_COLUMNS_FOR_EXPORT: List[ColumnAndFieldNames] = [
     ColumnAndFieldNames(column_name="Contact email", field_name="email"),
@@ -429,6 +441,12 @@ FEEDBACK_SURVEY_COLUMNS_FOR_EXPORT: List[ColumnAndFieldNames] = [
     ColumnAndFieldNames(
         column_name="Feedback survey sent?", field_name="is_feedback_requested"
     ),
+    ColumnAndFieldNames(
+        column_name="Parental organisation name",
+        field_name="parental_organisation_name",
+    ),
+    ColumnAndFieldNames(column_name="Website name", field_name="website_name"),
+    ColumnAndFieldNames(column_name="Sub-category", field_name="subcategory"),
 ]
 
 
@@ -481,6 +499,9 @@ def filter_cases(form: CaseSearchForm) -> QuerySet[Case]:  # noqa: C901
                     | Q(home_page_url__icontains=search)
                     | Q(psb_location__icontains=search)
                     | Q(sector__name__icontains=search)
+                    | Q(parental_organisation_name__icontains=search)
+                    | Q(website_name__icontains=search)
+                    | Q(subcategory__name__icontains=search)
                 )
         for filter_name in ["is_complaint", "enforcement_body"]:
             filter_value: str = form.cleaned_data.get(filter_name, NO_FILTER)

--- a/accessibility_monitoring_platform/apps/common/models.py
+++ b/accessibility_monitoring_platform/apps/common/models.py
@@ -253,6 +253,7 @@ class SubCategory(models.Model):
     name = models.TextField(default="", blank=True)
 
     class Meta:
+        verbose_name_plural = "Sub categories"
         ordering = ["name"]
 
     def __str__(self) -> str:

--- a/amp_platform.DockerFile
+++ b/amp_platform.DockerFile
@@ -18,4 +18,4 @@ CMD make static_files_process \
     && python manage.py collectstatic --noinput \
     && python manage.py migrate \
     && python manage.py recache_statuses \
-    && waitress-serve --port=8001 --threads=4 accessibility_monitoring_platform.wsgi:application
+    && waitress-serve --port=8001 --threads=5 accessibility_monitoring_platform.wsgi:application


### PR DESCRIPTION
* Use new case details fields; Show website name all over the UI ([example](https://platform.accessibility-monitoring.service.gov.uk/reports/370/report-publisher/)) [#1452](https://trello.com/c/2eCxFDGd/1452-use-new-case-details-fields)