### PR TITLE
1469: Remove statement overview from statement section choices

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/forms.py
+++ b/accessibility_monitoring_platform/apps/audits/forms.py
@@ -57,6 +57,7 @@ from .models import (
     StatementCheckResult,
     STATEMENT_CHECK_CHOICES,
     STATEMENT_CHECK_TYPE_CHOICES,
+    STATEMENT_CHECK_TYPE_OVERVIEW,
 )
 
 CHECK_RESULT_TYPE_FILTER_CHOICES: List[Tuple[str, str]] = TEST_TYPE_CHOICES + [
@@ -1436,4 +1437,12 @@ class StatementCheckCreateUpdateForm(forms.ModelForm):
             "type",
             "success_criteria",
             "report_text",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["type"].choices = [
+            (value, label)
+            for value, label in STATEMENT_CHECK_TYPE_CHOICES
+            if value != STATEMENT_CHECK_TYPE_OVERVIEW
         ]

--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -278,10 +278,10 @@ STATEMENT_CHECK_TYPE_FEEDBACK: str = "feedback"
 STATEMENT_CHECK_TYPE_CUSTOM: str = "custom"
 STATEMENT_CHECK_TYPE_CHOICES: List[Tuple[str, str]] = [
     (STATEMENT_CHECK_TYPE_OVERVIEW, "Statement overview"),
-    (STATEMENT_CHECK_TYPE_WEBSITE, "Accessibility statement for [website.com]"),
+    (STATEMENT_CHECK_TYPE_WEBSITE, "Statement information"),
     (STATEMENT_CHECK_TYPE_COMPLIANCE, "Compliance status"),
     (STATEMENT_CHECK_TYPE_NON_ACCESSIBLE, "Non-accessible content"),
-    (STATEMENT_CHECK_TYPE_PREPARATION, "Preparation of this accessibility statement"),
+    (STATEMENT_CHECK_TYPE_PREPARATION, "Statement preparation"),
     (STATEMENT_CHECK_TYPE_FEEDBACK, "Feedback and enforcement procedure"),
     (STATEMENT_CHECK_TYPE_CUSTOM, "Custom statement issues"),
 ]

--- a/accessibility_monitoring_platform/apps/audits/tests/test_forms.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_forms.py
@@ -1,0 +1,17 @@
+"""
+Test forms of audits app
+"""
+
+from ..forms import StatementCheckCreateUpdateForm
+from ..models import STATEMENT_CHECK_TYPE_CHOICES, STATEMENT_CHECK_TYPE_OVERVIEW
+
+
+def test_statement_overview_not_in_type_choices():
+    """Tests statement overview has been removed from type choices"""
+
+    form: StatementCheckCreateUpdateForm = StatementCheckCreateUpdateForm()
+
+    assert len(form.fields["type"].choices) == len(STATEMENT_CHECK_TYPE_CHOICES) - 1
+    assert STATEMENT_CHECK_TYPE_OVERVIEW not in [
+        value for value, _ in form.fields["type"].choices
+    ]


### PR DESCRIPTION
Trello card [#1469](https://trello.com/c/Fy6KXD5U/1469-remove-the-option-to-add-statement-issues-to-statement-overview).