### PR TITLE
1483: Remove no-initial-statement warning from statement overview page

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/retest_statement_overview.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/retest_statement_overview.html
@@ -32,8 +32,6 @@
                         <div class="govuk-grid-column-full">
                             {% if audit.accessibility_statement_initially_found or audit.twelve_week_accessibility_statement_found %}
                                 {% include 'audits/helpers/retest_statement_check_formset.html' %}
-                            {% else %}
-                                {% include 'audits/helpers/no_statement_at_retest.html' %}
                             {% endif %}
                             {% include 'common/amp_form_snippet.html' %}
                         </div>

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/statement_overview.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/statement_overview.html
@@ -24,18 +24,16 @@
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-full">
-                            {% if audit.accessibility_statement_initially_found %}
+                    {% if audit.accessibility_statement_initially_found %}
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
                                 {% include 'common/amp_field.html' with field=form.accessibility_statement_backup_url %}
                                 {% if audit.accessibility_statement_backup_url_date %}
                                     <p class="govuk-body amp-margin-top-minus-20"> Added {{ audit.accessibility_statement_backup_url_date }} </p>
                                 {% endif %}
-                            {% else %}
-                                {% include 'audits/helpers/no_statement_warning.html' %}
-                            {% endif %}
+                            </div>
                         </div>
-                    </div>
+                    {% endif %}
                     {% include 'audits/helpers/statement_check_formset.html' %}
                     <div class="govuk-grid-row">
                         <div class="govuk-grid-column-full">

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -1486,7 +1486,6 @@ def test_statement_check_results_hidden_when_no_statement_page_on_retest(
 
     assert response.status_code == 200
 
-    assertContains(response, NO_ACCESSIBILITY_STATEMENT_ON_RETEST, html=True)
     assertNotContains(response, field_label)
 
     page: Page = audit.accessibility_statement_page
@@ -1499,7 +1498,6 @@ def test_statement_check_results_hidden_when_no_statement_page_on_retest(
 
     assert response.status_code == 200
 
-    assertNotContains(response, NO_ACCESSIBILITY_STATEMENT_ON_RETEST, html=True)
     assertContains(response, field_label)
 
     page.not_found = BOOLEAN_TRUE
@@ -1511,7 +1509,6 @@ def test_statement_check_results_hidden_when_no_statement_page_on_retest(
 
     assert response.status_code == 200
 
-    assertContains(response, NO_ACCESSIBILITY_STATEMENT_ON_RETEST, html=True)
     assertNotContains(response, field_label)
 
 
@@ -1520,7 +1517,6 @@ def test_statement_check_results_hidden_when_no_statement_page_on_retest(
     [
         "audits:edit-audit-retest-statement-1",
         "audits:edit-audit-retest-statement-2",
-        "audits:edit-retest-statement-overview",
     ],
 )
 def test_12_week_statement_page_shown_on_retest(url_name, admin_client):
@@ -1550,6 +1546,41 @@ def test_12_week_statement_page_shown_on_retest(url_name, admin_client):
     assert response.status_code == 200
 
     assertNotContains(response, NO_12_WEEK_STATEMENT_ON_RETEST_TEXT)
+    assertContains(response, TWELVE_WEEK_STATEMENT_ON_RETEST_TEXT)
+    assertContains(response, ACCESSIBILITY_STATEMENT_12_WEEK_URL)
+
+
+@pytest.mark.parametrize(
+    "url_name",
+    [
+        "audits:edit-retest-statement-overview",
+    ],
+)
+def test_12_week_statement_page_shown_on_retest(url_name, admin_client):
+    """
+    Test that option to add 12-week accessibility statement shown.
+    """
+    audit: Audit = create_audit_and_statement_check_results()
+    audit_pk: Dict[str, int] = {"pk": audit.id}
+
+    response: HttpResponse = admin_client.get(
+        reverse(url_name, kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertNotContains(response, TWELVE_WEEK_STATEMENT_ON_RETEST_TEXT)
+    assertNotContains(response, ACCESSIBILITY_STATEMENT_12_WEEK_URL)
+
+    audit.twelve_week_accessibility_statement_url = ACCESSIBILITY_STATEMENT_12_WEEK_URL
+    audit.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse(url_name, kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
     assertContains(response, TWELVE_WEEK_STATEMENT_ON_RETEST_TEXT)
     assertContains(response, ACCESSIBILITY_STATEMENT_12_WEEK_URL)
 


### PR DESCRIPTION
Trello card [#1483](https://trello.com/c/V9Q4p8MM/1483-remove-obsolete-warning).