### PR TITLE
v0.6.35 - Replace Add comment button with link

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/qa_process.html
@@ -37,13 +37,8 @@
                                 </summary>
                                 <div class="govuk-details__text">
                                     <div class="govuk-button-group">
-                                        <input
-                                            type="submit"
-                                            value="Add comment"
-                                            name="add_comment"
-                                            class="govuk-button govuk-button--secondary"
-                                            data-module="govuk-button"
-                                        />
+                                        <a href="{% url 'cases:add-qa-comment' case.id %}" class="govuk-link govuk-link--no-visited-state">
+                                            Add comment</a>
                                     </div>
                                     {% for comment in case.qa_comments %}
                                         {% include "comments/helpers/comment.html" %}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1095,24 +1095,6 @@ def test_add_qa_comment(admin_client, admin_user):
     assert event.type == EVENT_TYPE_MODEL_CREATE
 
 
-def test_add_comment_button_redirects_to_add_comment(admin_client):
-    """Test pressing add comment button redirects to add comment"""
-    case: Case = Case.objects.create()
-
-    response: HttpResponse = admin_client.post(
-        reverse("cases:edit-qa-process", kwargs={"pk": case.id}),
-        {
-            "add_comment": "Add comment",
-            "version": case.version,
-        },
-    )
-    assert response.status_code == 302
-    assert (
-        response.url
-        == f'{reverse("cases:add-qa-comment", kwargs={"case_id": case.id})}'
-    )
-
-
 def test_add_qa_comment_redirects_to_qa_process(admin_client):
     """Test adding a QA comment redirects to QA process page"""
     case: Case = Case.objects.create()

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -448,8 +448,6 @@ class CaseQAProcessUpdateView(CaseUpdateView):
         """
         Detect the submit button used and act accordingly.
         """
-        if "add_comment" in self.request.POST:
-            return reverse("cases:add-qa-comment", kwargs={"case_id": self.object.id})
         if "save_continue" in self.request.POST:
             return reverse("cases:edit-contact-details", kwargs={"pk": self.object.id})
         return super().get_success_url()

--- a/accessibility_monitoring_platform/apps/dashboard/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/dashboard/tests/test_utils.py
@@ -1,5 +1,5 @@
 """Test dashboard utility functions"""
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date
 from typing import List, Union
 
@@ -29,7 +29,7 @@ class MockCase:
     """Mock of case for testing"""
 
     id: int
-    status: MockCaseStatus = MockCaseStatus(status="unknown")
+    status: MockCaseStatus = field(default_factory=MockCaseStatus)
     qa_status: str = "unknown"
     report_sent_date: Union[date, None] = None
     report_followup_week_12_due_date: Union[date, None] = None


### PR DESCRIPTION
* Replace Add comment button with link ([example](https://platform.accessibility-monitoring.service.gov.uk/cases/1170/edit-qa-process/)) [#1471](https://trello.com/c/j0gqVGln/1471-case-changed-since-this-page-loaded-error)