### PR TITLE
1482: Add 12-week statement check results to outstanding issues email

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
+++ b/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
@@ -321,7 +321,13 @@ class AuditRetestStatementCheckingView(AuditUpdateView):
                 for (
                     retest_statement_check_results_form
                 ) in retest_statement_check_results_formset.forms:
-                    retest_statement_check_results_form.save()
+                    statement_check_result: StatementCheckResult = (
+                        retest_statement_check_results_form.save(commit=False)
+                    )
+                    record_model_update_event(
+                        user=self.request.user, model_object=statement_check_result
+                    )
+                    statement_check_result.save()
             else:
                 return super().form_invalid(form)
 

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
@@ -92,32 +92,36 @@
                         We found no major issues.
                     {% endif %}
                     <h2>Your statement</h2>
-                    {{ case.audit.get_archive_accessibility_statement_state_display }}
                     {% if case.audit.uses_statement_checks %}
-                        <table id="email-statement-issues-table">
-                            <thead>
-                                <tr>
-                                    <th width=1%>#</th>
-                                    <th id="statement-issue" width=49%>Issue</th>
-                                    <th id="statement-12-week-update" width=49%>Organisation 12-week update</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {% for statement_check_result in case.audit.outstanding_statement_check_results %}
-                                    <tr valign="top">
-                                        <td width=1%>{{ forloop.counter }}</td>
-                                        <td headers="statement-issue" width=49%>
-                                            <p>{{ statement_check_result.statement_check.report_text }}</p>
-                                            {{ statement_check_result.report_comment|markdown_to_html }}
-                                        </td>
-                                        <td headers="statement-12-week-update" width=49%>
-                                            {{ statement_check_result.retest_comment|markdown_to_html }}
-                                        </td>
+                        {% if case.audit.outstanding_statement_check_results %}
+                            <table id="email-statement-issues-table">
+                                <thead>
+                                    <tr>
+                                        <th width=1%>#</th>
+                                        <th id="statement-issue" width=49%>Issue</th>
+                                        <th id="statement-12-week-update" width=49%>Organisation 12-week update</th>
                                     </tr>
-                                {% endfor %}
-                            </tbody>
-                        </table>
+                                </thead>
+                                <tbody>
+                                    {% for statement_check_result in case.audit.outstanding_statement_check_results %}
+                                        <tr valign="top">
+                                            <td width=1%>{{ forloop.counter }}</td>
+                                            <td headers="statement-issue" width=49%>
+                                                <p>{{ statement_check_result.statement_check.report_text }}</p>
+                                                {{ statement_check_result.report_comment|markdown_to_html }}
+                                            </td>
+                                            <td headers="statement-12-week-update" width=49%>
+                                                {{ statement_check_result.retest_comment|markdown_to_html }}
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                </tbody>
+                            </table>
+                        {% else %}
+                            We found no major issues.
+                        {% endif %}
                     {% else %}
+                        {{ case.audit.get_archive_accessibility_statement_state_display }}
                         {% if case.audit.archive_accessibility_statement_state == 'found-but' %}
                             <ul>
                                 {% for issue in case.audit.report_accessibility_issues %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/outstanding_issues.html
@@ -93,12 +93,38 @@
                     {% endif %}
                     <h2>Your statement</h2>
                     {{ case.audit.get_archive_accessibility_statement_state_display }}
-                    {% if case.audit.archive_accessibility_statement_state == 'found-but' %}
-                        <ul>
-                            {% for issue in case.audit.report_accessibility_issues %}
-                                <li>{{ issue }}</li>
-                            {% endfor %}
-                        </ul>
+                    {% if case.audit.uses_statement_checks %}
+                        <table id="email-statement-issues-table">
+                            <thead>
+                                <tr>
+                                    <th width=1%>#</th>
+                                    <th id="statement-issue" width=49%>Issue</th>
+                                    <th id="statement-12-week-update" width=49%>Organisation 12-week update</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for statement_check_result in case.audit.outstanding_statement_check_results %}
+                                    <tr valign="top">
+                                        <td width=1%>{{ forloop.counter }}</td>
+                                        <td headers="statement-issue" width=49%>
+                                            <p>{{ statement_check_result.statement_check.report_text }}</p>
+                                            {{ statement_check_result.report_comment|markdown_to_html }}
+                                        </td>
+                                        <td headers="statement-12-week-update" width=49%>
+                                            {{ statement_check_result.retest_comment|markdown_to_html }}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% else %}
+                        {% if case.audit.archive_accessibility_statement_state == 'found-but' %}
+                            <ul>
+                                {% for issue in case.audit.report_accessibility_issues %}
+                                    <li>{{ issue }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
                     {% endif %}
                     <br>
                     <br>

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -184,6 +184,8 @@ UNRESOLVED_EQUALITY_BODY_MESSAGE: str = (
     "Unresolved equality body correspondence message"
 )
 UNRESOLVED_EQUALITY_BODY_NOTES: str = "Unresolved equality body correspondence notes"
+STATEMENT_CHECK_RESULT_REPORT_COMMENT: str = "Statement check result report comment"
+STATEMENT_CHECK_RESULT_RETEST_COMMENT: str = "Statement check result retest comment"
 
 
 def add_user_to_auditor_groups(user: User) -> None:
@@ -3129,16 +3131,31 @@ def test_outstanding_issues_email_template_contains_issues(admin_client):
     page.save()
     Report.objects.create(case=audit.case)
     url: str = reverse("cases:outstanding-issues-email", kwargs={"pk": audit.case.id})
+    statement_check: StatementCheck = StatementCheck.objects.filter(type=type).first()
+    statement_check_result: StatementCheckResult = StatementCheckResult.objects.create(
+        audit=audit,
+        type=type,
+        statement_check=statement_check,
+        check_result_state=STATEMENT_CHECK_NO,
+        report_comment=STATEMENT_CHECK_RESULT_REPORT_COMMENT,
+        retest_state=STATEMENT_CHECK_NO,
+        retest_comment=STATEMENT_CHECK_RESULT_RETEST_COMMENT,
+    )
 
     response: HttpResponse = admin_client.get(url)
 
     assert response.status_code == 200
 
     assertContains(response, ERROR_NOTES)
+    assertContains(response, STATEMENT_CHECK_RESULT_REPORT_COMMENT)
+    assertContains(response, STATEMENT_CHECK_RESULT_RETEST_COMMENT)
 
     for check_result in audit.failed_check_results:
         check_result.retest_state = RETEST_CHECK_RESULT_FIXED
         check_result.save()
+
+    statement_check_result.retest_state = STATEMENT_CHECK_YES
+    statement_check_result.save()
 
     url: str = reverse("cases:outstanding-issues-email", kwargs={"pk": audit.case.id})
 
@@ -3147,6 +3164,8 @@ def test_outstanding_issues_email_template_contains_issues(admin_client):
     assert response.status_code == 200
 
     assertNotContains(response, ERROR_NOTES)
+    assertNotContains(response, STATEMENT_CHECK_RESULT_REPORT_COMMENT)
+    assertNotContains(response, STATEMENT_CHECK_RESULT_RETEST_COMMENT)
 
 
 def test_outstanding_issues_email_template_contains_no_issues(admin_client):


### PR DESCRIPTION
Trello card [#1481](https://trello.com/c/VnbH6Uml/1482-oustanding-issues-email-shows-no-statement-issues-regardless-whether-issues-were-found-design-attached).