### PR TITLE
1510: Override govuk header font size and weight

### DIFF
--- a/accessibility_monitoring_platform/templates/base.html
+++ b/accessibility_monitoring_platform/templates/base.html
@@ -46,14 +46,14 @@
                 <!--[if IE 8]>
                 <img src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image" width="36" height="32">
                 <![endif]-->
-                <span class="govuk-header__logotype-text">
+                <span class="govuk-header__logotype-text amp-govuk-header-logotype-text">
                   GOV.UK
                 </span>
               </span>
             </a>
           </div>
           <div class="govuk-header__content">
-            <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <a href="/" class="govuk-header__link govuk-header__link--homepage amp-govuk-header-link">
               <span class="govuk-header__link--service-name">
                 Accessibility monitoring platform
                 {% if django_settings.COPILOT_APPLICATION_NAME != None %}

--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -764,3 +764,12 @@ svg {
     color: white;
     background: maroon;
 }
+
+.amp-govuk-header-logotype-text {
+    font-weight: 700;
+}
+
+.amp-govuk-header-link {
+    font-size: 24px;
+    font-weight: 700;
+}

--- a/report_viewer/templates/base.html
+++ b/report_viewer/templates/base.html
@@ -37,14 +37,14 @@
                 <!--[if IE 8]>
                 <img src="/assets/images/govuk-logotype-crown.png" class="govuk-header__logotype-crown-fallback-image" width="36" height="32">
                 <![endif]-->
-                <span class="govuk-header__logotype-text">
+                <span class="govuk-header__logotype-text amp-govuk-header-logotype-text">
                   GOV.UK
                 </span>
               </span>
             </a>
           </div>
           <div class="govuk-header__content">
-            <a href="/" class="govuk-header__link govuk-header__link--homepage">
+            <a href="/" class="govuk-header__link govuk-header__link--homepage amp-govuk-header-link">
               <span class="govuk-header__link--service-name">
                 Accessibility monitoring reports
               </span>


### PR DESCRIPTION
Trello card [#1510](https://trello.com/c/4NqniQI3/1510-restore-pre-gds-design-system-500-headers).