### PR TITLE
1428: Show case overdue if report is ready to send and seven day no contact email sent date is more than seven days ago

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/models.py
+++ b/accessibility_monitoring_platform/apps/cases/models.py
@@ -545,6 +545,10 @@ class Case(VersionModel):
 
     @property
     def next_action_due_date(self) -> Optional[date]:
+        if self.status.status == "report-ready-to-send":
+            if self.seven_day_no_contact_email_sent_date:
+                return self.seven_day_no_contact_email_sent_date + timedelta(days=7)
+
         if self.status.status == "in-report-correspondence":
             if self.report_followup_week_1_sent_date is None:
                 return self.report_followup_week_1_due_date

--- a/accessibility_monitoring_platform/apps/cases/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_models.py
@@ -258,6 +258,25 @@ def test_formatted_home_page_url(url, expected_formatted_url):
 
 
 @pytest.mark.django_db
+def test_next_action_due_date_for_report_ready_to_send():
+    """
+    Check that the next_action_due_date is correctly returned
+    when case status is report ready to send.
+    """
+    seven_day_no_contact_email_sent_date: date = date(2020, 4, 1)
+
+    case: Case = Case.objects.create(
+        seven_day_no_contact_email_sent_date=seven_day_no_contact_email_sent_date,
+    )
+    case.status.status = "report-ready-to-send"
+
+    assert (
+        case.next_action_due_date
+        == seven_day_no_contact_email_sent_date + timedelta(days=7)
+    )
+
+
+@pytest.mark.django_db
 def test_next_action_due_date_for_in_report_correspondence():
     """
     Check that the next_action_due_date is correctly calculated

--- a/accessibility_monitoring_platform/apps/overdue/templates/overdue/overdue_list.html
+++ b/accessibility_monitoring_platform/apps/overdue/templates/overdue/overdue_list.html
@@ -42,7 +42,11 @@
                                 {{ overdue_case.status.get_status_display }}
                             </td>
                             <td class="govuk-table__cell amp-width-one-quarter">
-                                {% if overdue_case.status.status == "in-report-correspondence" %}
+                                {% if overdue_case.status.status == "report-ready-to-send" %}
+                                    <a href="{% url 'cases:edit-report-correspondence' overdue_case.id %}" class="govuk-link govuk-link--no-visited-state">
+                                        Seven day 'no contact details' response overdue
+                                    </a>
+                                {% elif overdue_case.status.status == "in-report-correspondence" %}
                                     <a href="{% url 'cases:edit-report-correspondence' overdue_case.id %}" class="govuk-link govuk-link--no-visited-state">
                                         {{ overdue_case.in_report_correspondence_progress }}
                                     </a>

--- a/accessibility_monitoring_platform/apps/overdue/tests.py
+++ b/accessibility_monitoring_platform/apps/overdue/tests.py
@@ -52,6 +52,24 @@ def create_case(user: User) -> Case:
 
 
 @pytest.mark.django_db
+def test_report_ready_to_send_seven_day_no_contact():
+    """
+    Show overdue if report is ready to send and seven day no
+    contact email sent date is more than seven days ago.
+    """
+    user: User = User.objects.create()
+
+    case: Case = create_case(user)
+
+    assert len(get_overdue_cases(user)) == 0
+
+    case.seven_day_no_contact_email_sent_date = ONE_WEEK_AGO
+    case.save()
+
+    assert len(get_overdue_cases(user)) == 1
+
+
+@pytest.mark.django_db
 def test_returns_no_overdue_cases():
     """Creates seven cases that are all in correspondence with the PSB but require no further actions.
 

--- a/accessibility_monitoring_platform/apps/overdue/utils.py
+++ b/accessibility_monitoring_platform/apps/overdue/utils.py
@@ -16,6 +16,11 @@ def get_overdue_cases(user_request: User) -> QuerySet[Case]:
         end_date: datetime = datetime.now() - timedelta(days=1)
         seven_days_ago = date.today() - timedelta(days=7)
 
+        seven_day_no_contact: QuerySet[Case] = user_cases.filter(
+            status__status__icontains="report-ready-to-send",
+            seven_day_no_contact_email_sent_date__range=[start_date, seven_days_ago],
+        )
+
         in_report_correspondence: QuerySet[Case] = user_cases.filter(
             Q(status__status="in-report-correspondence"),
             Q(
@@ -55,7 +60,10 @@ def get_overdue_cases(user_request: User) -> QuerySet[Case]:
         )
 
         in_correspondence: QuerySet[Case] = (
-            in_report_correspondence | in_probation_period | in_12_week_correspondence
+            seven_day_no_contact
+            | in_report_correspondence
+            | in_probation_period
+            | in_12_week_correspondence
         )
 
         in_correspondence: QuerySet[Case] = sorted(


### PR DESCRIPTION
Trello card [#1428](https://trello.com/c/KB1GWLJw/1428-add-7-day-overdue-notification-for-seven-day-no-contact-details-email-sent-report-correspondence).