### PR TITLE
1519: Correct spelling of nessage

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/equality_body_correspondence_list.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/equality_body_correspondence_list.html
@@ -61,7 +61,7 @@
                                 <p class="govuk-body-m">{{ equality_body_correspondence.created|amp_datetime }}</p>
                                 <p class="govuk-body-m amp-margin-bottom-5"><b>Type</b></p>
                                 <p class="govuk-body-m">{{ equality_body_correspondence.get_type_display }}</p>
-                                <p class="govuk-body-m amp-margin-bottom-5"><b>Zendesk nessage</b></p>
+                                <p class="govuk-body-m amp-margin-bottom-5"><b>Zendesk message</b></p>
                                 <div class="amp-report-wrapper">
                                     {% if equality_body_correspondence.message %}
                                         {{ equality_body_correspondence.message|markdown_to_html }}


### PR DESCRIPTION
Trello card [#1519](https://trello.com/c/X779YIcT/1519-correct-spelling-mistake-in-zendesk-correspondence-mgmt-nessage-should-be-message).