### PR TITLE
1535: Add warnings to correspondence UI

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -432,6 +432,14 @@ class CaseOneWeekFollowupUpdateForm(VersionForm):
             "one_week_followup_complete_date",
         ]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        case: Case = self.instance
+        if case and case.report_acknowledged_date:
+            self.fields["report_followup_week_1_sent_date"].widget = forms.HiddenInput()
+            self.fields["report_followup_week_1_due_date"].widget = forms.HiddenInput()
+            self.fields["one_week_followup_sent_to_email"].widget = forms.HiddenInput()
+
 
 class CaseFourWeekFollowupUpdateForm(VersionForm):
     """
@@ -460,6 +468,14 @@ class CaseFourWeekFollowupUpdateForm(VersionForm):
             "correspondence_notes",
             "four_week_followup_complete_date",
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        case: Case = self.instance
+        if case and case.report_acknowledged_date:
+            self.fields["report_followup_week_4_sent_date"].widget = forms.HiddenInput()
+            self.fields["report_followup_week_4_due_date"].widget = forms.HiddenInput()
+            self.fields["four_week_followup_sent_to_email"].widget = forms.HiddenInput()
 
 
 class CaseReportAcknowledgedUpdateForm(VersionForm):
@@ -546,6 +562,20 @@ class CaseOneWeekFollowupFinalUpdateForm(VersionForm):
             "twelve_week_correspondence_notes",
             "one_week_followup_final_complete_date",
         ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        case: Case = self.instance
+        if case and case.twelve_week_correspondence_acknowledged_date:
+            self.fields[
+                "twelve_week_1_week_chaser_sent_date"
+            ].widget = forms.HiddenInput()
+            self.fields[
+                "twelve_week_1_week_chaser_due_date"
+            ].widget = forms.HiddenInput()
+            self.fields[
+                "twelve_week_1_week_chaser_sent_to_email"
+            ].widget = forms.HiddenInput()
 
 
 class CaseTwelveWeekUpdateAcknowledgedUpdateForm(VersionForm):

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/four_week_followup.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/four_week_followup.html
@@ -25,12 +25,9 @@
                             {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
                             {% if case.report_acknowledged_date %}
                                 {% include 'cases/helpers/report_acknowledged_warning.html' %}
-                                <div class="amp-display-none">
-                            {% endif %}
-                            {% include 'cases/helpers/amp_due_date_field.html' with field=form.report_followup_week_4_sent_date due_date=case.report_followup_week_4_due_date due_date_field=form.report_followup_week_4_due_date %}
-                            {% include 'cases/helpers/amp_email_field.html' with field=form.four_week_followup_sent_to_email %}
-                            {% if case.report_acknowledged_date %}
-                                </div>
+                            {% else %}
+                                {% include 'cases/helpers/amp_due_date_field.html' with field=form.report_followup_week_4_sent_date due_date=case.report_followup_week_4_due_date due_date_field=form.report_followup_week_4_due_date %}
+                                {% include 'cases/helpers/amp_email_field.html' with field=form.four_week_followup_sent_to_email %}
                             {% endif %}
                             {% include 'common/amp_field.html' with field=form.correspondence_notes %}
                             {% include 'common/amp_field.html' with field=form.four_week_followup_complete_date %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/four_week_followup.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/four_week_followup.html
@@ -23,8 +23,15 @@
                         <div class="govuk-grid-column-full">
                             {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                             {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
+                            {% if case.report_acknowledged_date %}
+                                {% include 'cases/helpers/report_acknowledged_warning.html' %}
+                                <div class="amp-display-none">
+                            {% endif %}
                             {% include 'cases/helpers/amp_due_date_field.html' with field=form.report_followup_week_4_sent_date due_date=case.report_followup_week_4_due_date due_date_field=form.report_followup_week_4_due_date %}
                             {% include 'cases/helpers/amp_email_field.html' with field=form.four_week_followup_sent_to_email %}
+                            {% if case.report_acknowledged_date %}
+                                </div>
+                            {% endif %}
                             {% include 'common/amp_field.html' with field=form.correspondence_notes %}
                             {% include 'common/amp_field.html' with field=form.four_week_followup_complete_date %}
                         </div>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup.html
@@ -25,12 +25,9 @@
                             {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
                             {% if case.report_acknowledged_date %}
                                 {% include 'cases/helpers/report_acknowledged_warning.html' %}
-                                <div class="amp-display-none">
-                            {% endif %}
+                            {% else %}
                                 {% include 'cases/helpers/amp_due_date_field.html' with field=form.report_followup_week_1_sent_date due_date=case.report_followup_week_1_due_date due_date_field=form.report_followup_week_1_due_date %}
                                 {% include 'cases/helpers/amp_email_field.html' with field=form.one_week_followup_sent_to_email %}
-                            {% if case.report_acknowledged_date %}
-                                </div>
                             {% endif %}
                             {% include 'common/amp_field.html' with field=form.correspondence_notes %}
                             {% include 'common/amp_field.html' with field=form.one_week_followup_complete_date %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup.html
@@ -23,8 +23,15 @@
                         <div class="govuk-grid-column-full">
                             {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                             {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-                            {% include 'cases/helpers/amp_due_date_field.html' with field=form.report_followup_week_1_sent_date due_date=case.report_followup_week_1_due_date due_date_field=form.report_followup_week_1_due_date %}
-                            {% include 'cases/helpers/amp_email_field.html' with field=form.one_week_followup_sent_to_email %}
+                            {% if case.report_acknowledged_date %}
+                                {% include 'cases/helpers/report_acknowledged_warning.html' %}
+                                <div class="amp-display-none">
+                            {% endif %}
+                                {% include 'cases/helpers/amp_due_date_field.html' with field=form.report_followup_week_1_sent_date due_date=case.report_followup_week_1_due_date due_date_field=form.report_followup_week_1_due_date %}
+                                {% include 'cases/helpers/amp_email_field.html' with field=form.one_week_followup_sent_to_email %}
+                            {% if case.report_acknowledged_date %}
+                                </div>
+                            {% endif %}
                             {% include 'common/amp_field.html' with field=form.correspondence_notes %}
                             {% include 'common/amp_field.html' with field=form.one_week_followup_complete_date %}
                         </div>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup_final.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup_final.html
@@ -23,8 +23,15 @@
                         <div class="govuk-grid-column-full">
                             {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                             {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
+                            {% if case.twelve_week_correspondence_acknowledged_date %}
+                                {% include 'cases/helpers/final_request_acknowledged_warning.html' %}
+                                <div class="amp-display-none">
+                            {% endif %}
                             {% include 'cases/helpers/amp_due_date_field.html' with field=form.twelve_week_1_week_chaser_sent_date due_date=case.twelve_week_1_week_chaser_due_date due_date_field=form.twelve_week_1_week_chaser_due_date %}
                             {% include 'cases/helpers/amp_email_field.html' with field=form.twelve_week_1_week_chaser_sent_to_email %}
+                            {% if case.twelve_week_correspondence_acknowledged_date %}
+                                </div>
+                            {% endif %}
                             {% include 'common/amp_field.html' with field=form.twelve_week_correspondence_notes %}
                             {% include 'common/amp_field.html' with field=form.one_week_followup_final_complete_date %}
                         </div>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup_final.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/one_week_followup_final.html
@@ -25,12 +25,9 @@
                             {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
                             {% if case.twelve_week_correspondence_acknowledged_date %}
                                 {% include 'cases/helpers/final_request_acknowledged_warning.html' %}
-                                <div class="amp-display-none">
-                            {% endif %}
-                            {% include 'cases/helpers/amp_due_date_field.html' with field=form.twelve_week_1_week_chaser_sent_date due_date=case.twelve_week_1_week_chaser_due_date due_date_field=form.twelve_week_1_week_chaser_due_date %}
-                            {% include 'cases/helpers/amp_email_field.html' with field=form.twelve_week_1_week_chaser_sent_to_email %}
-                            {% if case.twelve_week_correspondence_acknowledged_date %}
-                                </div>
+                            {% else %}
+                                {% include 'cases/helpers/amp_due_date_field.html' with field=form.twelve_week_1_week_chaser_sent_date due_date=case.twelve_week_1_week_chaser_due_date due_date_field=form.twelve_week_1_week_chaser_due_date %}
+                                {% include 'cases/helpers/amp_email_field.html' with field=form.twelve_week_1_week_chaser_sent_to_email %}
                             {% endif %}
                             {% include 'common/amp_field.html' with field=form.twelve_week_correspondence_notes %}
                             {% include 'common/amp_field.html' with field=form.one_week_followup_final_complete_date %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/final_request_acknowledged_warning.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/final_request_acknowledged_warning.html
@@ -1,0 +1,8 @@
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        The request for a final update has been acknowledged by the organisation,
+        and no further follow-up is needed.
+    </strong>
+</div>

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/report_acknowledged_warning.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/report_acknowledged_warning.html
@@ -1,0 +1,7 @@
+<div class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-warning-text__assistive">Warning</span>
+        The report has been acknowledged by the organisation, and no further follow-up is needed.
+    </strong>
+</div>

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -163,6 +163,10 @@ UNRESOLVED_EQUALITY_BODY_MESSAGE: str = (
 UNRESOLVED_EQUALITY_BODY_NOTES: str = "Unresolved equality body correspondence notes"
 STATEMENT_CHECK_RESULT_REPORT_COMMENT: str = "Statement check result report comment"
 STATEMENT_CHECK_RESULT_RETEST_COMMENT: str = "Statement check result retest comment"
+REPORT_ACKNOWLEDGED_WARNING: str = "The report has been acknowledged by the organisation, and no further follow-up is needed."
+TWELVE_WEEK_CORES_ACKNOWLEDGED_WARNING: str = (
+    "The request for a final update has been acknowledged by the organisation"
+)
 
 
 def add_user_to_auditor_groups(user: User) -> None:
@@ -1409,6 +1413,33 @@ def test_case_report_one_week_followup_contains_followup_due_date(admin_client):
     )
 
 
+def test_case_report_one_week_followup_shows_warning_if_report_ack(admin_client):
+    """
+    Test that the case report one week followup view shows a warning if the report
+    has been acknowledged
+    """
+    case: Case = Case.objects.create()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-one-week-followup", kwargs={"pk": case.id})
+    )
+
+    assert response.status_code == 200
+
+    assertNotContains(response, REPORT_ACKNOWLEDGED_WARNING)
+
+    case.report_acknowledged_date = TODAY
+    case.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-one-week-followup", kwargs={"pk": case.id})
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, REPORT_ACKNOWLEDGED_WARNING)
+
+
 def test_case_report_four_week_followup_contains_followup_due_date(admin_client):
     """Test that the case report four week followup view contains the followup due date"""
     case: Case = Case.objects.create(
@@ -1427,9 +1458,36 @@ def test_case_report_four_week_followup_contains_followup_due_date(admin_client)
     )
 
 
+def test_case_report_four_week_followup_shows_warning_if_report_ack(admin_client):
+    """
+    Test that the case report four week followup view shows a warning if the report
+    has been acknowledged
+    """
+    case: Case = Case.objects.create()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-four-week-followup", kwargs={"pk": case.id})
+    )
+
+    assert response.status_code == 200
+
+    assertNotContains(response, REPORT_ACKNOWLEDGED_WARNING)
+
+    case.report_acknowledged_date = TODAY
+    case.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-four-week-followup", kwargs={"pk": case.id})
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, REPORT_ACKNOWLEDGED_WARNING)
+
+
 def test_case_report_twelve_week_1_week_chaser_contains_followup_due_date(admin_client):
     """
-    Test that the One week followup for final update view contains the one week chaser due date
+    Test that the one week followup for final update view contains the one week chaser due date
     """
     case: Case = Case.objects.create(
         twelve_week_1_week_chaser_due_date=ONE_WEEK_CHASER_DUE_DATE,
@@ -1445,6 +1503,35 @@ def test_case_report_twelve_week_1_week_chaser_contains_followup_due_date(admin_
         response,
         f"Due {amp_format_date(ONE_WEEK_CHASER_DUE_DATE)}",
     )
+
+
+def test_case_report_twelve_week_1_week_chaser_shows_warning_if_12_week_cores_ack(
+    admin_client,
+):
+    """
+    Test that the one week followup for final update view shows a warning if the 12-week
+    correspondence has been acknowledged
+    """
+    case: Case = Case.objects.create()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-one-week-followup-final", kwargs={"pk": case.id})
+    )
+
+    assert response.status_code == 200
+
+    assertNotContains(response, TWELVE_WEEK_CORES_ACKNOWLEDGED_WARNING)
+
+    case.twelve_week_correspondence_acknowledged_date = TODAY
+    case.save()
+
+    response: HttpResponse = admin_client.get(
+        reverse("cases:edit-one-week-followup-final", kwargs={"pk": case.id})
+    )
+
+    assert response.status_code == 200
+
+    assertContains(response, TWELVE_WEEK_CORES_ACKNOWLEDGED_WARNING)
 
 
 def test_no_psb_response_redirects_to_case_close(admin_client):


### PR DESCRIPTION
Trello card [#1535](https://trello.com/c/hDiiKfAc/1535-add-notification-in-correspondence-pages-when-the-org-responds-to-the-report-and-update-request).