### PR TITLE
1540: Close statement links' details elements by default

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/statement_pages.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/statement_pages.html
@@ -1,4 +1,4 @@
-<details class="govuk-details" data-module="govuk-details" open>
+<details class="govuk-details" data-module="govuk-details">
     <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text">
             Statement links


### PR DESCRIPTION
Trello card [#1540](https://trello.com/c/DnNbXpF3/1540-have-statement-links-closed-by-default-in-the-statement-assessment).