### PR TITLE
1599: Add link to open contact details on new tab

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_statement_1.html
@@ -34,11 +34,7 @@
                                 {% include 'common/amp_field.html' with field=form.archive_audit_retest_feedback_notes %}
                                 {% include 'audits/helpers/retest_statement_field_info.html' with name='Contact Information' example='audits/archive_statement_examples/contact_information_state.html' decision=audit.get_archive_contact_information_state_display notes=audit.archive_contact_information_notes %}
                                 {% include 'common/amp_field.html' with field=form.archive_audit_retest_contact_information_state %}
-                                <p class="govuk-body-m">
-                                    <a href="{% url 'cases:edit-contact-details' audit.case.id %}"
-                                        rel="noreferrer noopener" target="_blank" class="govuk-link govuk-link--no-visited-state">
-                                        Open contact details page in new tab</a>
-                                </p>
+                                {% include 'cases/helpers/contact_details_link.html' with case=audit.case %}
                                 {% include 'common/amp_field.html' with field=form.archive_audit_retest_contact_information_notes %}
                                 {% include 'audits/helpers/retest_statement_field_info.html' with name='Enforcement Procedure' example='audits/archive_statement_examples/enforcement_procedure_state.html' decision=audit.get_archive_enforcement_procedure_state_display notes=audit.archive_enforcement_procedure_notes %}
                                 {% include 'common/amp_field.html' with field=form.archive_audit_retest_enforcement_procedure_state %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/find_contact_details.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/find_contact_details.html
@@ -15,6 +15,7 @@
             <div class="govuk-grid-column-two-thirds">
                 {% include 'cases/helpers/correspondence_overview_detail.html' %}
                 {% include 'common/error_summary.html' %}
+                {% include 'cases/helpers/contact_details_link.html' %}
                 {% include 'cases/helpers/no_response_link.html' %}
                 <form method="post" action="{% url 'cases:edit-find-contact-details' case.id %}">
                     {% csrf_token %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/contact_details_link.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/contact_details_link.html
@@ -1,0 +1,8 @@
+<p class="govuk-body-m">
+    <a
+        href="{% url 'cases:edit-contact-details' case.id %}"
+        class="govuk-link govuk-link--no-visited-state" target="_blank"
+    >
+        Open contact details page in new tab
+    </a>
+</p>

--- a/accessibility_monitoring_platform/apps/common/templates/common/frequently_used_links.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/frequently_used_links.html
@@ -86,9 +86,4 @@
             </a>
         </li>
     {% endfor %}
-    <li>
-        <a href="{% url 'cases:edit-contact-details' case.id %}"
-            rel="noreferrer noopener" target="_blank" class="govuk-link govuk-link--no-visited-state">
-            Open contact details page in new tab</a>
-    </li>
 </ul>


### PR DESCRIPTION
Trello card [#1599](https://trello.com/c/SZXHAC80/1599-add-link-open-contact-details-page-above-unable-to-send-report-or-no-response-from-public-sector-body-in-correspondence-pages).