### PR TITLE
1433: Copy matching error notes in 12-week retest

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -1,6 +1,7 @@
 """
 Models - audits (called tests by the users)
 """
+
 from datetime import date
 from typing import Dict, List, Optional
 
@@ -1222,6 +1223,24 @@ class CheckResult(models.Model):
     def save(self, *args, **kwargs) -> None:
         self.updated = timezone.now()
         super().save(*args, **kwargs)
+
+    @property
+    def other_messages(self) -> Dict[str, str]:
+        """Other results with notes for matching WCAGDefinition"""
+        return (
+            self.audit.failed_check_results.filter(wcag_definition=self.wcag_definition)
+            .exclude(page=self.page)
+            .exclude(notes="")
+        )
+
+    @property
+    def other_retest_messages(self) -> Dict[str, str]:
+        """Other results with retest notes for matching WCAGDefinition"""
+        return (
+            self.audit.failed_check_results.filter(wcag_definition=self.wcag_definition)
+            .exclude(page=self.page)
+            .exclude(retest_notes="")
+        )
 
 
 class StatementCheck(models.Model):

--- a/accessibility_monitoring_platform/apps/audits/models.py
+++ b/accessibility_monitoring_platform/apps/audits/models.py
@@ -1225,17 +1225,8 @@ class CheckResult(models.Model):
         super().save(*args, **kwargs)
 
     @property
-    def other_messages(self) -> Dict[str, str]:
-        """Other results with notes for matching WCAGDefinition"""
-        return (
-            self.audit.failed_check_results.filter(wcag_definition=self.wcag_definition)
-            .exclude(page=self.page)
-            .exclude(notes="")
-        )
-
-    @property
-    def other_retest_messages(self) -> Dict[str, str]:
-        """Other results with retest notes for matching WCAGDefinition"""
+    def matching_wcag_with_retest_notes_check_results(self) -> Dict[str, str]:
+        """Other check results with retest notes for matching WCAGDefinition"""
         return (
             self.audit.failed_check_results.filter(wcag_definition=self.wcag_definition)
             .exclude(page=self.page)

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
@@ -82,7 +82,7 @@
                                 <div class="govuk-hint">{{ check_result.notes|markdown_to_html }}</div>
                                 {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
                                 {% include 'audits/helpers/amp_wcag_state_field.html' with field=form.retest_state %}
-                                {% if check_result.other_retest_messages %}
+                                {% if check_result.matching_wcag_with_retest_notes_check_results %}
                                     <details class="govuk-details" data-module="govuk-details">
                                         <summary class="govuk-details__summary">
                                             <span class="govuk-details__summary-text">
@@ -91,7 +91,7 @@
                                         </summary>
                                         <div class="govuk-details__text">
                                             <ul class="govuk-list govuk-list--bullet amp-margin-bottom-10">
-                                            {% for other_check_result in check_result.other_retest_messages %}
+                                            {% for other_check_result in check_result.matching_wcag_with_retest_notes_check_results %}
                                                 <li>
                                                     <b>{{ other_check_result.page }}</b>
                                                     <textarea id="{{ form.retest_notes.auto_id }}-{{ forloop.counter }}" hidden>{{ other_check_result.retest_notes }}</textarea>
@@ -108,6 +108,7 @@
                                     </details>
                                 {% endif %}
                                 {% include 'audits/helpers/amp_wcag_state_field.html' with field=form.retest_notes %}
+                                {% include 'common/preview_markdown.html' with field_id=form.retest_notes.auto_id %}
                             </div>
                         </div>
                     {% endfor %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
@@ -80,7 +80,34 @@
                                 <hr class="amp-width-100 amp-margin-bottom-30">
                                 <label class="govuk-label"><b>{{ check_result.wcag_definition }}</b></label>
                                 <div class="govuk-hint">{{ check_result.notes|markdown_to_html }}</div>
-                                {% include 'common/amp_form_snippet.html' %}
+                                {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
+                                {% include 'audits/helpers/amp_wcag_state_field.html' with field=form.retest_state %}
+                                {% if check_result.other_retest_messages %}
+                                    <details class="govuk-details" data-module="govuk-details">
+                                        <summary class="govuk-details__summary">
+                                            <span class="govuk-details__summary-text">
+                                                Matching errors
+                                            </span>
+                                        </summary>
+                                        <div class="govuk-details__text">
+                                            <ul class="govuk-list govuk-list--bullet amp-margin-bottom-10">
+                                            {% for other_check_result in check_result.other_retest_messages %}
+                                                <li>
+                                                    <b>{{ other_check_result.page }}</b>
+                                                    <textarea id="{{ form.retest_notes.auto_id }}-{{ forloop.counter }}" hidden>{{ other_check_result.retest_notes }}</textarea>
+                                                    <span tabIndex="0"
+                                                        class="amp-control amp-copy-error"
+                                                        sourceId="{{ form.retest_notes.auto_id }}-{{ forloop.counter }}"
+                                                        targetId="{{ form.retest_notes.auto_id }}">
+                                                        Click to populate error details</span>
+                                                    {{ other_check_result.retest_notes|markdown_to_html }}
+                                                </li>
+                                            {% endfor %}
+                                            </ul>
+                                        </div>
+                                    </details>
+                                {% endif %}
+                                {% include 'audits/helpers/amp_wcag_state_field.html' with field=form.retest_notes %}
                             </div>
                         </div>
                     {% endfor %}
@@ -114,6 +141,11 @@
             </div>
         </div>
     </main>
-    <script src="{% static 'js/audits_check_filter.js' %}"></script>
 </div>
+{% endblock %}
+
+{% block extrascript %}
+<script src="{% static 'js/audits_check_filter.js' %}"></script>
+<script src="{% static 'js/audits_copy_error.js' %}"></script>
+<script src="{% static 'js/markdown_preview.js' %}"></script>
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
+++ b/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
@@ -1,6 +1,7 @@
 """
 Views for audits app (called tests by users)
 """
+
 from datetime import date
 from typing import Any, Dict, List, Tuple, Type, Union
 
@@ -336,11 +337,13 @@ class AuditRetestStatementCheckingView(AuditUpdateView):
 
         if audit.accessibility_statement_found:
             if self.request.POST:
-                retest_statement_check_results_formset: AuditRetestStatementCheckResultFormset = AuditRetestStatementCheckResultFormset(
-                    self.request.POST
-                )
+                retest_statement_check_results_formset: (
+                    AuditRetestStatementCheckResultFormset
+                ) = AuditRetestStatementCheckResultFormset(self.request.POST)
             else:
-                retest_statement_check_results_formset: AuditRetestStatementCheckResultFormset = AuditRetestStatementCheckResultFormset(
+                retest_statement_check_results_formset: (
+                    AuditRetestStatementCheckResultFormset
+                ) = AuditRetestStatementCheckResultFormset(
                     queryset=StatementCheckResult.objects.filter(
                         audit=self.object, type=self.statement_check_type
                     )
@@ -357,9 +360,9 @@ class AuditRetestStatementCheckingView(AuditUpdateView):
         context: Dict[str, Any] = self.get_context_data()
         audit: Audit = self.object
         if audit.accessibility_statement_found:
-            retest_statement_check_results_formset: AuditRetestStatementCheckResultFormset = context[
-                "retest_statement_check_results_formset"
-            ]
+            retest_statement_check_results_formset: (
+                AuditRetestStatementCheckResultFormset
+            ) = context["retest_statement_check_results_formset"]
             if retest_statement_check_results_formset.is_valid():
                 for (
                     retest_statement_check_results_form

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/case_close.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/case_close.html
@@ -105,7 +105,7 @@
                                     <li>
                                         {{ required_data_missing_column.column_header }} is missing
                                         {% if required_data_missing_column.edit_url %}
-                                            (<a href="{{ required_data_missing_column.edit_url }}" class="govuk-link govuk-link--no-visited-state">{{ required_data_missing_column.edit_url_label }}{% if required_data_missing_column.edit_url_label == 'Edit' %}<span class="govuk-visually-hidden"> {{ required_data_missing_column.column_header }}</span>{% endif %}</a>)
+                                            <span class="amp-nowrap">(<a href="{{ required_data_missing_column.edit_url }}" class="govuk-link govuk-link--no-visited-state">{{ required_data_missing_column.edit_url_label }}{% if required_data_missing_column.edit_url_label == 'Edit' %}<span class="govuk-visually-hidden"> {{ required_data_missing_column.column_header }}</span>{% endif %}</a>)</span>
                                         {% endif %}
                                     </li>
                                 {% endfor %}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -3628,7 +3628,8 @@ def test_case_close_missing_data(admin_client):
         response,
         """<li>
             Organisation is missing
-            (<a href="/cases/1/edit-case-details/#id_organisation_name-label" class="govuk-link govuk-link--no-visited-state">Edit<span class="govuk-visually-hidden"> Organisation</span></a>)
+            <span class="amp-nowrap">(<a href="/cases/1/edit-case-details/#id_organisation_name-label" class="govuk-link govuk-link--no-visited-state">
+                Edit<span class="govuk-visually-hidden"> Organisation</span></a>)</span>
         </li>""",
         html=True,
     )
@@ -3636,7 +3637,8 @@ def test_case_close_missing_data(admin_client):
         response,
         """<li>
             Website URL is missing
-            (<a href="/cases/1/edit-case-details/#id_home_page_url-label" class="govuk-link govuk-link--no-visited-state">Edit<span class="govuk-visually-hidden"> Website URL</span></a>)
+            <span class="amp-nowrap">(<a href="/cases/1/edit-case-details/#id_home_page_url-label" class="govuk-link govuk-link--no-visited-state">
+                Edit<span class="govuk-visually-hidden"> Website URL</span></a>)</span>
         </li>""",
         html=True,
     )
@@ -3649,7 +3651,8 @@ def test_case_close_missing_data(admin_client):
         response,
         """<li>
             Enforcement recommendation is missing
-            (<a href="/cases/1/edit-enforcement-recommendation/#id_recommendation_for_enforcement-label" class="govuk-link govuk-link--no-visited-state">Edit<span class="govuk-visually-hidden"> Enforcement recommendation</span></a>)
+            <span class="amp-nowrap">(<a href="/cases/1/edit-enforcement-recommendation/#id_recommendation_for_enforcement-label" class="govuk-link govuk-link--no-visited-state">
+                Edit<span class="govuk-visually-hidden"> Enforcement recommendation</span></a>)</span>
         </li>""",
         html=True,
     )
@@ -3657,7 +3660,8 @@ def test_case_close_missing_data(admin_client):
         response,
         """<li>
             Enforcement recommendation notes including exemptions is missing
-            (<a href="/cases/1/edit-enforcement-recommendation/#id_recommendation_notes-label" class="govuk-link govuk-link--no-visited-state">Edit<span class="govuk-visually-hidden"> Enforcement recommendation notes including exemptions</span></a>)
+            <span class="amp-nowrap">(<a href="/cases/1/edit-enforcement-recommendation/#id_recommendation_notes-label" class="govuk-link govuk-link--no-visited-state">
+                Edit<span class="govuk-visually-hidden"> Enforcement recommendation notes including exemptions</span></a>)</span>
         </li>""",
         html=True,
     )
@@ -3665,7 +3669,8 @@ def test_case_close_missing_data(admin_client):
         response,
         """<li>
             Date when compliance decision email sent to public sector body is missing
-            (<a href="/cases/1/edit-enforcement-recommendation/#id_compliance_email_sent_date-label" class="govuk-link govuk-link--no-visited-state">Edit<span class="govuk-visually-hidden"> Date when compliance decision email sent to public sector body</span></a>)
+            <span class="amp-nowrap">(<a href="/cases/1/edit-enforcement-recommendation/#id_compliance_email_sent_date-label" class="govuk-link govuk-link--no-visited-state">
+                Edit<span class="govuk-visually-hidden"> Date when compliance decision email sent to public sector body</span></a>)</span>
         </li>""",
         html=True,
     )

--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -764,3 +764,7 @@ svg {
     color: white;
     background: maroon;
 }
+
+.amp-nowrap {
+    white-space: nowrap;
+}

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-django==4.2.10
+django==4.2.11
 python-dotenv
 psycopg2
 notifications-python-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ cryptography==42.0.4
     # via moto
 dj-database-url==2.1.0
     # via -r requirements.in
-django==4.2.10
+django==4.2.11
     # via
     #   -r requirements.in
     #   dj-database-url


### PR DESCRIPTION
Trello card [#1433](https://trello.com/c/MEeQxGvd/1433-add-option-to-add-multipage-errors-in-12-week-test-like-how-its-done-in-the-initial-test-design-attached).