### PR TITLE
1608: Suppress page_url when user is not logged in. May be upsetting security checking

### DIFF
--- a/accessibility_monitoring_platform/apps/common/templates/common/phase_banner.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/phase_banner.html
@@ -6,7 +6,7 @@
             {% if django_settings.AMP_PROTOTYPE_NAME and django_settings.AMP_PROTOTYPE_NAME != 'TEST' %}
                 report
             {% else %}
-                <a href="{% url 'common:issue-report' %}?page_url={{ request.path }}"
+                <a href="{% url 'common:issue-report' %}{% if user.is_authenticated %}?page_url={{ request.path }}{% endif %}"
                     target="_blank"
                     class="govuk-link govuk-link--no-visited-state">report</a>
             {% endif %}

--- a/accessibility_monitoring_platform/apps/common/templates/common/phase_banner.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/phase_banner.html
@@ -1,3 +1,4 @@
+{% if user.is_authenticated %}
 <div class="govuk-phase-banner">
     <p class="govuk-phase-banner__content">
         <strong class="govuk-tag govuk-phase-banner__content__tag">Alpha</strong>
@@ -6,7 +7,7 @@
             {% if django_settings.AMP_PROTOTYPE_NAME and django_settings.AMP_PROTOTYPE_NAME != 'TEST' %}
                 report
             {% else %}
-                <a href="{% url 'common:issue-report' %}{% if user.is_authenticated %}?page_url={{ request.path }}{% endif %}"
+                <a href="{% url 'common:issue-report' %}?page_url={{ request.path }}"
                     target="_blank"
                     class="govuk-link govuk-link--no-visited-state">report</a>
             {% endif %}
@@ -14,3 +15,4 @@
         </span>
     </p>
 </div>
+{% endif %}

--- a/accessibility_monitoring_platform/templates/navbar.html
+++ b/accessibility_monitoring_platform/templates/navbar.html
@@ -31,7 +31,12 @@
                 <ul class="govuk-list nav-menu-list">
                     <li><a class="govuk-link govuk-link--no-visited-state" href="{% url 'dashboard:home' %}">Home</a></li>
                     <li><a class="govuk-link govuk-link--no-visited-state" href="{% url 'users:edit-user' request.user.id %}">Settings</a></li>
-                    <li><a class="govuk-link govuk-link--no-visited-state" href="{% url 'logout' %}">Sign out</a></li>
+                    <li>
+                        <form method="post" action="{% url 'logout' %}">
+                            {% csrf_token %}
+                            <button type="submit" class="amp-button-as-link amp-margin-left-15 govuk-body-m">Sign out</button>
+                        </form>
+                    </li>
                     <li class="amp-padding-left-10"> | </li>
                     <li class="amp-padding-left-10"> {{ user.first_name|title }} {{ user.last_name|title }} </li>
                 </ul>

--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -207,6 +207,10 @@ img, .amp-max-width-100 {
     margin-left: 10px;
 }
 
+.amp-margin-left-15 {
+    margin-left: 15px;
+}
+
 .amp-margin-right-0 {
     margin-right: 0 !important;
 }


### PR DESCRIPTION
Trello card [#1608](https://trello.com/c/fRqdCOMt/1608-prevent-access-to-the-report-an-issue-page-or-forward-on-the-login-page).