### PR TITLE
1612: Upgrade GDS Design System to v5.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^5.2.0",
+        "govuk-frontend": "^5.3.0",
         "showdown": "2.1.0"
       },
       "devDependencies": {
@@ -9396,9 +9396,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.2.0.tgz",
-      "integrity": "sha512-beD3wztHpkKz6JUpPwnwop1ejb4rTFMPLCutKLCIDmUS4BPpW59ggVUfctsRqHd2Zjw9wxljdRdeIJ8AZFyyTw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.0.tgz",
+      "integrity": "sha512-w6yaaDU3nqhVmWJFnOuJKRIUEB/2RrTFGzoA3z5n4cTG9h292EseT/q+JJA/LYTf5IYzeTIVAUbE5fFjUxefiQ==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^5.2.0",
+    "govuk-frontend": "^5.3.0",
     "showdown": "2.1.0"
   },
   "standard": {


### PR DESCRIPTION
Trello card [#1612](https://trello.com/c/9a9om3hN/1612-upgrade-gds-design-system-to-v53).