### PR TITLE
1609: Remove deprecated uses of os.path and os.system from platform

### DIFF
--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -30,16 +30,16 @@ elif DEBUG and not UNDER_TEST:
 
 load_dotenv()
 
-PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+CURRENT_FILE: Path = Path(__file__)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR: Path = CURRENT_FILE.parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/3.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.getenv("SECRET_KEY")
+SECRET_KEY = os.environ["SECRET_KEY"]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 
@@ -110,8 +110,8 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
-            os.path.join(BASE_DIR, "templates"),
-            os.path.join(BASE_DIR.parent, "common/templates"),
+            BASE_DIR / "templates",
+            BASE_DIR.parent / "common" / "templates",
         ],
         "APP_DIRS": True,
         "OPTIONS": {
@@ -136,11 +136,11 @@ if UNDER_TEST or INTEGRATION_TEST:
     if INTEGRATION_TEST:
         DATABASES["default"] = {
             "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("POSTGRES_NAME"),
-            "USER": os.environ.get("POSTGRES_USER"),
-            "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
-            "HOST": os.environ.get("POSTGRES_HOST"),
-            "PORT": os.environ.get("POSTGRES_PORT"),
+            "NAME": os.environ["POSTGRES_NAME"],
+            "USER": os.environ["POSTGRES_USER"],
+            "PASSWORD": os.environ["POSTGRES_PASSWORD"],
+            "HOST": os.environ["POSTGRES_HOST"],
+            "PORT": os.environ["POSTGRES_PORT"],
         }
     else:
         DATABASES["default"] = {
@@ -231,9 +231,10 @@ STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 )
 
-STATICFILES_DIRS = [f"{Path(BASE_DIR).parent}/common/static/compiled"]
-STATIC_URL = os.path.join(BASE_DIR, "/static/")
-STATIC_ROOT = os.path.join(BASE_DIR, "static/dist")
+STATICFILES_DIRS = [BASE_DIR.parent / "common" / "static" / "compiled"]
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "static" / "dist"
+
 STORAGES = {
     "staticfiles": {
         "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
@@ -292,10 +293,10 @@ CSP_SCRIPT_SRC = ("'self'",)
 CSP_FONT_SRC = ("'self'",)
 CSP_IMG_SRC = ("'self'", "data:")
 
-aws_prototype_filename: str = "aws_prototype.json"
-if os.path.isfile(aws_prototype_filename):
-    aws_prototype_file = open(aws_prototype_filename, "r")
-    aws_prototype_data: str = json.load(aws_prototype_file)
+AWS_PROTOTYPE_FILE: Path = Path("aws_prototype.json")
+if AWS_PROTOTYPE_FILE.exists():
+    aws_prototype_text: str = AWS_PROTOTYPE_FILE.read_text()
+    aws_prototype_data: dict = json.loads(aws_prototype_text)
     AMP_PROTOTYPE_NAME = aws_prototype_data["prototype_name"]
     AMP_PROTOCOL: str = aws_prototype_data["amp_protocol"]
     AMP_VIEWER_DOMAIN: str = aws_prototype_data["viewer_domain"]

--- a/accessibility_monitoring_platform/settings/deploy.py
+++ b/accessibility_monitoring_platform/settings/deploy.py
@@ -3,6 +3,7 @@ Production deployment settings
 """
 
 import os
+from pathlib import Path
 
 from .base import *
 
@@ -21,8 +22,8 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-aws_prototype_filename: str = "aws_prototype.json"
-if os.path.isfile(aws_prototype_filename):
+AWS_PROTOTYPE_FILE: Path = Path("aws_prototype.json")
+if AWS_PROTOTYPE_FILE.exists():
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 elif os.getenv("NOTIFY_API_KEY"):
     EMAIL_BACKEND = "accessibility_monitoring_platform.email.NotifyEmailBackend"

--- a/accessibility_monitoring_platform/templates/500.html
+++ b/accessibility_monitoring_platform/templates/500.html
@@ -12,13 +12,13 @@
     <link href="{% static 'css/init.css' %}" rel="stylesheet" media="screen">
     <link href="{% static 'css/init.css' %}" rel="stylesheet" media="print">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/static/assets/images/favicon.ico" type="image/x-icon">
-    <link rel="mask-icon" href="/static/assets/images/govuk-mask-icon.svg" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/assets/images/govuk-apple-touch-icon-180x180.png"/>
-    <link rel="apple-touch-icon" sizes="167x167" href="/static/assets/images/govuk-apple-touch-icon-167x167.png"/>
-    <link rel="apple-touch-icon" sizes="152x152" href="/static/assets/images/govuk-apple-touch-icon-152x152.png"/>
-    <link rel="apple-touch-icon" sizes="152x152" href="/static/assets/images/govuk-apple-touch-icon.png"/>
-    <meta property="og:image" content="/static/assets/images/govuk-opengraph-image.png">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% static 'assets/images/favicon.ico' %)" type="image/x-icon">
+    <link rel="mask-icon" href="{% static 'assets/images/govuk-mask-icon.svg' %}" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'assets/images/govuk-apple-touch-icon-180x180.png' %}"/>
+    <link rel="apple-touch-icon" sizes="167x167" href="{% static 'assets/images/govuk-apple-touch-icon-167x167.png' %}"/>
+    <link rel="apple-touch-icon" sizes="152x152" href="{% static 'assets/images/govuk-apple-touch-icon-152x152.png' %}"/>
+    <link rel="apple-touch-icon" sizes="152x152" href="{% static 'assets/images/govuk-apple-touch-icon.png' %}"/>
+    <meta property="og:image" content="{% static 'assets/images/govuk-opengraph-image.png' %}">
     <meta name="description" content="Accessibility Monitoring Platform">
   </head>
   <body class="govuk-template__body govuk-frontend-supported">

--- a/accessibility_monitoring_platform/templates/base.html
+++ b/accessibility_monitoring_platform/templates/base.html
@@ -12,12 +12,12 @@
     <link href="{% static 'css/init.css' %}" rel="stylesheet" media="screen">
     <link href="{% static 'css/init.css' %}" rel="stylesheet" media="print">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/static/assets/images/favicon.ico" type="image/x-icon">
-    <link rel="mask-icon" href="/static/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/assets/images/govuk-icon-180.png"/>
-    <link rel="apple-touch-icon" sizes="192x192" href="/static/assets/images/govuk-icon-192.png"/>
-    <link rel="apple-touch-icon" sizes="512x512" href="/static/assets/images/govuk-icon-512.png"/>
-    <meta property="og:image" content="/static/assets/images/govuk-opengraph-image.png">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% static 'assets/images/favicon.ico' %}" type="image/x-icon">
+    <link rel="mask-icon" href="{% static 'assets/images/govuk-icon-mask.svg' %}" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'assets/images/govuk-icon-180.png' %}"/>
+    <link rel="apple-touch-icon" sizes="192x192" href="{% static 'assets/images/govuk-icon-192.png' %}"/>
+    <link rel="apple-touch-icon" sizes="512x512" href="{% static 'assets/images/govuk-icon-512.png' %}"/>
+    <meta property="og:image" content="{% static 'assets/images/govuk-opengraph-image.png' %}">
     <meta name="description" content="Accessibility Monitoring Platform">
   </head>
   <body class="govuk-template__body govuk-frontend-supported">

--- a/common/templates/reports_common/accessibility_report_container.html
+++ b/common/templates/reports_common/accessibility_report_container.html
@@ -4,7 +4,7 @@
     <main id="main-content" class="govuk-main-wrapper amp-report-wrapper no-padding-on-main">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <img src="/static/img/gds-co-logo.png" width="369" height="100"
+                <img src="{% static 'img/gds-co-logo.png' %}" width="369" height="100"
                     class="gds-co-image"
                     alt="Logos of Government Digital Service and Cabinet Office"
                 />

--- a/report_viewer/settings/base.py
+++ b/report_viewer/settings/base.py
@@ -30,12 +30,11 @@ elif DEBUG and not UNDER_TEST:
 
 load_dotenv()
 
-PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
+CURRENT_FILE: Path = Path(__file__)
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 # BASE_DIR = Path(__file__).resolve().parent.parent
-
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR: Path = CURRENT_FILE.parent.parent
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
@@ -94,8 +93,8 @@ TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
-            os.path.join(BASE_DIR, "templates"),
-            os.path.join(BASE_DIR.parent, "common/templates"),
+            BASE_DIR / "templates",
+            BASE_DIR.parent / "common" / "templates",
         ],
         "APP_DIRS": True,
         "OPTIONS": {
@@ -124,11 +123,11 @@ if UNDER_TEST or INTEGRATION_TEST:
     if INTEGRATION_TEST:
         DATABASES["default"] = {
             "ENGINE": "django.db.backends.postgresql",
-            "NAME": os.environ.get("POSTGRES_NAME"),
-            "USER": os.environ.get("POSTGRES_USER"),
-            "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
-            "HOST": os.environ.get("POSTGRES_HOST"),
-            "PORT": os.environ.get("POSTGRES_PORT"),
+            "NAME": os.environ["POSTGRES_NAME"],
+            "USER": os.environ["POSTGRES_USER"],
+            "PASSWORD": os.environ["POSTGRES_PASSWORD"],
+            "HOST": os.environ["POSTGRES_HOST"],
+            "PORT": os.environ["POSTGRES_PORT"],
         }
     else:
         DATABASES["default"] = {
@@ -230,9 +229,9 @@ STATICFILES_FINDERS = (
     "django.contrib.staticfiles.finders.AppDirectoriesFinder",
 )
 
-STATICFILES_DIRS = [f"{Path(BASE_DIR).parent}/common/static/compiled"]
-STATIC_URL = os.path.join(BASE_DIR, "/static/")
-STATIC_ROOT = os.path.join(BASE_DIR, "static/dist")
+STATICFILES_DIRS = [BASE_DIR.parent / "common" / "static" / "compiled"]
+STATIC_URL = "/static/"
+STATIC_ROOT = BASE_DIR / "static" / "dist"
 
 STORAGES = {
     "staticfiles": {

--- a/report_viewer/settings/deploy.py
+++ b/report_viewer/settings/deploy.py
@@ -1,7 +1,9 @@
 """
 Production deployment settings
 """
+
 import os
+from pathlib import Path
 
 from .base import *
 
@@ -20,8 +22,8 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-aws_prototype_filename: str = "aws_prototype.json"
-if os.path.isfile(aws_prototype_filename):
+AWS_PROTOTYPE_FILE: Path = Path("aws_prototype.json")
+if AWS_PROTOTYPE_FILE.exists():
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 elif os.getenv("NOTIFY_API_KEY"):
     EMAIL_BACKEND = "accessibility_monitoring_platform.email.NotifyEmailBackend"

--- a/report_viewer/templates/base.html
+++ b/report_viewer/templates/base.html
@@ -12,12 +12,12 @@
     <link href="{% static 'css/init.css' %}" rel="stylesheet" media="screen">
     <link href="{% static 'css/init.css' %}" rel="stylesheet" media="print">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="/static/assets/images/favicon.ico" type="image/x-icon">
-    <link rel="mask-icon" href="/static/assets/images/govuk-icon-mask.svg" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="/static/assets/images/govuk-icon-180.png"/>
-    <link rel="apple-touch-icon" sizes="192x192" href="/static/assets/images/govuk-icon-192.png"/>
-    <link rel="apple-touch-icon" sizes="512x512" href="/static/assets/images/govuk-icon-512.png"/>
-    <meta property="og:image" content="/static/assets/images/govuk-opengraph-image.png">
+    <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% static 'assets/images/favicon.ico' %}" type="image/x-icon">
+    <link rel="mask-icon" href="{% static 'assets/images/govuk-icon-mask.svg' %}" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'assets/images/govuk-icon-180.png' %}"/>
+    <link rel="apple-touch-icon" sizes="192x192" href="{% static 'assets/images/govuk-icon-192.png' %}"/>
+    <link rel="apple-touch-icon" sizes="512x512" href="{% static 'assets/images/govuk-icon-512.png' %}"/>
+    <meta property="og:image" content="{% static 'assets/images/govuk-opengraph-image.png' %}">
     <meta name="description" content="Accessibility Monitoring Platform">
   </head>
   <body class="govuk-template__body govuk-frontend-supported">


### PR DESCRIPTION
Trello card [#1609](https://trello.com/c/TcD8c6YJ/1609-remove-os-from-the-codebase).