### PR TITLE
1663: Search for Cases by `case_number` instead of `id`

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/models.py
+++ b/accessibility_monitoring_platform/apps/cases/models.py
@@ -463,9 +463,7 @@ class Case(VersionModel):
         title: str = ""
         if self.website_name:
             title += f"{self.website_name} | "
-        title += (
-            f"{self.organisation_name} | {self.formatted_home_page_url} | #{self.id}"
-        )
+        title += f"{self.organisation_name} | {self.formatted_home_page_url} | #{self.case_number}"
         return title
 
     @property

--- a/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_utils.py
@@ -32,6 +32,7 @@ ORGANISATION_NAME: str = "Organisation name one"
 ORGANISATION_NAME_COMPLAINT: str = "Organisation name two"
 ORGANISATION_NAME_ECNI: str = "Organisation name ecni"
 ORGANISATION_NAME_EHRC: str = "Organisation name ehrc"
+CASE_NUMBER: int = 99
 
 CSV_EXPORT_FILENAME: str = "cases_export.csv"
 
@@ -108,6 +109,18 @@ def test_case_filtered_by_search_string():
 
     assert len(filtered_cases) == 1
     assert filtered_cases[0].organisation_name == ORGANISATION_NAME
+
+
+@pytest.mark.django_db
+def test_case_filtered_by_case_number_search_string():
+    """Test that searching for case by number is reflected in the queryset"""
+    Case.objects.create(case_number=CASE_NUMBER)
+    form: MockForm = MockForm(cleaned_data={"case_search": str(CASE_NUMBER)})
+
+    filtered_cases: List[Case] = list(filter_cases(form))
+
+    assert len(filtered_cases) == 1
+    assert filtered_cases[0].case_number == CASE_NUMBER
 
 
 @pytest.mark.django_db

--- a/accessibility_monitoring_platform/apps/cases/utils.py
+++ b/accessibility_monitoring_platform/apps/cases/utils.py
@@ -188,12 +188,12 @@ def get_case_view_sections(case: Case) -> List[ViewSection]:
             )
         ]
     if case.audit is not None:
-        testing_details_subsections: List[
-            FieldLabelAndValue
-        ] = get_initial_test_view_sections(audit=case.audit)
-        twelve_week_test_subsections: List[
-            FieldLabelAndValue
-        ] = get_twelve_week_test_view_sections(audit=case.audit)
+        testing_details_subsections: List[FieldLabelAndValue] = (
+            get_initial_test_view_sections(audit=case.audit)
+        )
+        twelve_week_test_subsections: List[FieldLabelAndValue] = (
+            get_twelve_week_test_view_sections(audit=case.audit)
+        )
         if case.report is not None:
             report_pk: Dict[str, int] = {"pk": case.report.id}
             report_details_fields: List[FieldLabelAndValue] = [
@@ -488,7 +488,7 @@ def filter_cases(form) -> QuerySet[Case]:  # noqa: C901
             if (
                 search.isdigit()
             ):  # if its just a number, it presumes its an ID and returns that case
-                search_query = Q(id=search)
+                search_query = Q(case_number=search)
             else:
                 search_query = (
                     Q(  # pylint: disable=unsupported-binary-operation
@@ -683,11 +683,11 @@ def get_post_case_alerts(user: User) -> List[PostCaseAlert]:
     """
     post_case_alerts: List[PostCaseAlert] = []
 
-    equality_body_correspondences: QuerySet[
-        EqualityBodyCorrespondence
-    ] = EqualityBodyCorrespondence.objects.filter(
-        case__auditor=user,
-        status=EqualityBodyCorrespondence.Status.UNRESOLVED,
+    equality_body_correspondences: QuerySet[EqualityBodyCorrespondence] = (
+        EqualityBodyCorrespondence.objects.filter(
+            case__auditor=user,
+            status=EqualityBodyCorrespondence.Status.UNRESOLVED,
+        )
     )
 
     for equality_body_correspondence in equality_body_correspondences:


### PR DESCRIPTION
Trello card [#1663](https://trello.com/c/Z73ZlNri/1663-use-case-number-in-title-and-search).