### PR TITLE
1667: Upgrade GovUK Frontend to version 5.4.0

### DIFF
--- a/common/static/scss/init.scss
+++ b/common/static/scss/init.scss
@@ -1,2 +1,2 @@
-@import 'node_modules/govuk-frontend/dist/govuk/all.scss';
+@import 'node_modules/govuk-frontend/dist/govuk/index.scss';
 @import 'global';

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^5.3.0",
+        "govuk-frontend": "^5.4.0",
         "showdown": "2.1.0"
       },
       "devDependencies": {
@@ -8734,9 +8734,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.3.0.tgz",
-      "integrity": "sha512-w6yaaDU3nqhVmWJFnOuJKRIUEB/2RrTFGzoA3z5n4cTG9h292EseT/q+JJA/LYTf5IYzeTIVAUbE5fFjUxefiQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.4.0.tgz",
+      "integrity": "sha512-F3YwQYrYQqIPfNxsoph6O78Ey1unCB6cy6omx8KeWY9G504lWZFBSIaiUCma1jNLw9bOUU7Ui+tXG09jjqy0Mw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^5.3.0",
+    "govuk-frontend": "^5.4.0",
     "showdown": "2.1.0"
   },
   "standard": {


### PR DESCRIPTION
Trello card [#1667](https://trello.com/c/wTQ9LFC4/1667-upgrade-govuk-frontend-to-540).