### PR TITLE
1678: Add red text for email templates

### DIFF
--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -781,3 +781,7 @@ svg {
     color: govuk-colour("red");
     font-weight: bold;
 }
+
+.amp-email-red {
+    color: govuk-colour("red");
+}


### PR DESCRIPTION
Trello card [#1678](https://trello.com/c/BR2SMhMV/1678-add-red-non-bold-style-for-email-templates).