### PR TITLE
v0.6.83 - Restrict unique report visits to current case

### DIFF
--- a/accessibility_monitoring_platform/apps/reports/views.py
+++ b/accessibility_monitoring_platform/apps/reports/views.py
@@ -171,30 +171,30 @@ class ReportVisitsMetricsView(ReportTemplateView):
         context: Dict[str, Any] = super().get_context_data(*args, **kwargs)
         context["showing"] = self.request.GET.get("showing")
         context["userhash"] = self.request.GET.get("userhash")
+        case: Case = context["report"].case
 
         if context["userhash"]:
             context["visit_logs"] = ReportVisitsMetrics.objects.filter(
-                case=context["report"].case,
+                case=case,
                 fingerprint_codename=context["userhash"],
             )
         elif context["showing"] == "unique-visitors":
             visit_logs: List[Any] = []
             disinct_values: QuerySet = (
-                ReportVisitsMetrics.objects.filter(case=context["report"].case)
+                ReportVisitsMetrics.objects.filter(case=case)
                 .values("fingerprint_hash")
                 .distinct()
             )
             for query_set in disinct_values:
                 visit_logs.append(
                     ReportVisitsMetrics.objects.filter(
-                        fingerprint_hash=query_set["fingerprint_hash"]
+                        case=case,
+                        fingerprint_hash=query_set["fingerprint_hash"],
                     ).first()
                 )
             visit_logs.sort(reverse=True, key=lambda x: x.id)
             context["visit_logs"] = visit_logs
         else:
-            context["visit_logs"] = ReportVisitsMetrics.objects.filter(
-                case=context["report"].case
-            )
+            context["visit_logs"] = ReportVisitsMetrics.objects.filter(case=case)
 
         return context

--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -781,3 +781,7 @@ svg {
     color: govuk-colour("red");
     font-weight: bold;
 }
+
+.amp-email-red {
+    color: govuk-colour("red");
+}


### PR DESCRIPTION
* Restrict unique report visits to current case ([example](https://platform.accessibility-monitoring.service.gov.uk/reports/370/report-metrics-view/?showing=unique-visitors)) [#1684](https://trello.com/c/NPQCgwor/1684-filter-unique-report-visits-by-report)