### PR TITLE
1666: Show when no contact details request sent on home page

### DIFF
--- a/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/6_report_ready_to_send.html
+++ b/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/6_report_ready_to_send.html
@@ -29,6 +29,8 @@
                             {% else %}
                                 No auditor
                             {% endif %}
+                        {% elif case.seven_day_no_contact_email_sent_date %}
+                            <a href="{% url 'cases:edit-find-contact-details' case.id %}" class="govuk-link">No contact details request sent</a>
                         {% else %}
                             <a href="{% url 'cases:edit-report-approved' case.id %}" class="govuk-link">Report approved</a>
                         {% endif %}

--- a/accessibility_monitoring_platform/apps/dashboard/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/dashboard/tests/test_views.py
@@ -1,6 +1,7 @@
 """
 Tests for view - dashboard
 """
+
 from datetime import date, datetime, timedelta
 
 import pytest
@@ -94,6 +95,31 @@ def test_dashboard_shows_link_to_closed_and_sent_cases(admin_client, admin_user)
             <a href="/cases/?auditor={admin_user.id}&status=case-closed-sent-to-equalities-body" class="govuk-link">
                 View all your cases with status "Case closed and sent to equalities body"</a>
         </p>""",
+        html=True,
+    )
+
+
+def test_dashboard_shows_link_to_no_contact_email_sent(admin_client, admin_user):
+    """Check dashboard contains link to find closed and sent to equalities body cases"""
+    case: Case = create_case_and_compliance(
+        home_page_url="https://www.website.com",
+        organisation_name="org name",
+        auditor=admin_user,
+        website_compliance_state_initial=CaseCompliance.WebsiteCompliance.COMPLIANT,
+        statement_compliance_state_initial=CaseCompliance.StatementCompliance.COMPLIANT,
+        report_review_status=Boolean.YES,
+        report_approved_status=Case.ReportApprovedStatus.APPROVED,
+        seven_day_no_contact_email_sent_date=date.today(),
+    )
+
+    response: HttpResponse = admin_client.get(reverse("dashboard:home"))
+
+    assert response.status_code == 200
+
+    assertContains(
+        response,
+        f"""<a href="{reverse('cases:edit-find-contact-details', kwargs={'pk': case.id})}" class="govuk-link">
+            No contact details request sent</a>""",
         html=True,
     )
 


### PR DESCRIPTION
Trello card [#1666](https://trello.com/c/8yQb75TW/1666-represent-no-contact-details-in-the-dashboard-home-page).