### PR TITLE
1700: Show 12-week statement checks even if no statement initially existed

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/twelve_week_retest_nav_steps.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/twelve_week_retest_nav_steps.html
@@ -33,9 +33,9 @@
                         {% include './nav_step.html' with edit_name='audits:edit-retest-statement-custom' name='12-week custom statement issues' complete=audit.audit_retest_statement_custom_complete_date %}
                     </ul>
                 </li>
-                {% include './nav_step.html' with edit_name='audits:edit-twelve-week-disproportionate-burden' name='12-week disproportionate burden claim' complete=audit.twelve_week_disproportionate_burden_complete_date %}
-                {% include './nav_step.html' with edit_name='audits:edit-audit-retest-statement-decision' name='12-week statement compliance decision' complete=audit.audit_retest_statement_decision_complete_date %}
             {% endif %}
+            {% include './nav_step.html' with edit_name='audits:edit-twelve-week-disproportionate-burden' name='12-week disproportionate burden claim' complete=audit.twelve_week_disproportionate_burden_complete_date %}
+            {% include './nav_step.html' with edit_name='audits:edit-audit-retest-statement-decision' name='12-week statement compliance decision' complete=audit.audit_retest_statement_decision_complete_date %}
         {% else %}
             {% include './nav_step.html' with edit_name='audits:edit-audit-retest-statement-1' name='12-week accessibility statement Pt. 1' complete=audit.archive_audit_retest_statement_1_complete_date %}
             {% include './nav_step.html' with edit_name='audits:edit-audit-retest-statement-2' name='12-week accessibility statement Pt. 2' complete=audit.archive_audit_retest_statement_2_complete_date %}

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -1272,6 +1272,30 @@ def test_audit_retest_statement_overview_updates_when_no_statement_exists(
     assert audit_from_db.audit_retest_statement_overview_complete_date == date.today()
 
 
+def test_audit_retest_statement_overview_no_statement(
+    admin_client,
+):
+    """
+    Test that the audit retest statement overview page shows checks
+    even if there is no statement page.
+    """
+    audit: Audit = create_audit_and_statement_check_results()
+    audit_pk: Dict[str, int] = {"pk": audit.id}
+    Page.objects.filter(page_type=Page.Type.STATEMENT).delete()
+
+    response: HttpResponse = admin_client.get(
+        reverse("audits:edit-retest-statement-overview", kwargs=audit_pk),
+    )
+
+    assert response.status_code == 200
+
+    assertContains(
+        response,
+        """<label class="govuk-label"><b>Success criteria</b></label>""",
+        html=True,
+    )
+
+
 def test_audit_retest_statement_overview_updates_statement_checkresult(
     admin_client,
 ):

--- a/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
+++ b/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
@@ -343,23 +343,22 @@ class AuditRetestStatementCheckingView(AuditUpdateView):
         context: Dict[str, Any] = super().get_context_data(**kwargs)
         audit: Audit = self.object
 
-        if audit.accessibility_statement_found:
-            if self.request.POST:
-                retest_statement_check_results_formset: (
-                    AuditRetestStatementCheckResultFormset
-                ) = AuditRetestStatementCheckResultFormset(self.request.POST)
-            else:
-                retest_statement_check_results_formset: (
-                    AuditRetestStatementCheckResultFormset
-                ) = AuditRetestStatementCheckResultFormset(
-                    queryset=StatementCheckResult.objects.filter(
-                        audit=self.object, type=self.statement_check_type
-                    )
+        if self.request.POST:
+            retest_statement_check_results_formset: (
+                AuditRetestStatementCheckResultFormset
+            ) = AuditRetestStatementCheckResultFormset(self.request.POST)
+        else:
+            retest_statement_check_results_formset: (
+                AuditRetestStatementCheckResultFormset
+            ) = AuditRetestStatementCheckResultFormset(
+                queryset=StatementCheckResult.objects.filter(
+                    audit=audit, type=self.statement_check_type
                 )
-
-            context["retest_statement_check_results_formset"] = (
-                retest_statement_check_results_formset
             )
+
+        context["retest_statement_check_results_formset"] = (
+            retest_statement_check_results_formset
+        )
 
         return context
 


### PR DESCRIPTION
Trello card [#1700](https://trello.com/c/VT1hp2oo/1700-there-are-no-overview-questions-during-the-12-week-statement-test-if-there-wasnt-a-statement-initially-this-is-clearly-a-bug-and).