### PR TITLE
1698: Relabel organisation_response

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -651,7 +651,7 @@ class CaseTwelveWeekUpdateAcknowledgedUpdateForm(VersionForm):
         label="12-week update request acknowledged by (email address)"
     )
     organisation_response = AMPChoiceRadioField(
-        label="If the organisation did not respond to the 12 week update request, select ‘Organisation did not respond to 12-week update’  (included in equality body export)",
+        label="If the organisation did not respond to the 12 week update request, select ‘Organisation did not respond to 12-week update’",
         help_text="This field affects the case status",
         choices=Case.OrganisationResponse.choices,
     )


### PR DESCRIPTION
TRello card [#1698](https://trello.com/c/ObZQ9c4G/1698-remove-included-in-equality-body-export-from-if-the-organisation-did-not-respond-to-the-12-week-update-request-field).