### PR TITLE
1703: Make `http` protocol prefixes optional in bulk URL search

### DIFF
--- a/accessibility_monitoring_platform/apps/common/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_utils.py
@@ -76,8 +76,8 @@ def test_extract_domain_from_url_http():
 
 
 def test_extract_domain_from_url_no_protocol():
-    """Tests that the domain is not extracted from a url with no protocol"""
-    assert extract_domain_from_url(url="example.com") == ""
+    """Tests that the domain is extracted from a url with no protocol"""
+    assert extract_domain_from_url(url="example.com") == "example.com"
 
 
 @pytest.mark.parametrize(
@@ -250,9 +250,9 @@ def test_get_recent_changes_to_platform():
         name="Recent"
     )
 
-    recent_changes_to_platform: QuerySet[
-        ChangeToPlatform
-    ] = get_recent_changes_to_platform()
+    recent_changes_to_platform: QuerySet[ChangeToPlatform] = (
+        get_recent_changes_to_platform()
+    )
 
     assert recent_changes_to_platform.count() == 1
     assert recent_change_to_platform in recent_changes_to_platform

--- a/accessibility_monitoring_platform/apps/common/utils.py
+++ b/accessibility_monitoring_platform/apps/common/utils.py
@@ -23,9 +23,11 @@ from .models import ChangeToPlatform, Event, Platform
 
 def extract_domain_from_url(url: str) -> str:
     """Extract and return domain string from url string"""
-    domain_match: Union[Match[str], None] = re.search(
-        "https?://([A-Za-z_0-9.-]+).*", url
-    )
+    if url.startswith("https://"):
+        url = url[8:]
+    elif url.startswith("http://"):
+        url = url[7:]
+    domain_match: Union[Match[str], None] = re.search("([A-Za-z_0-9.-]+).*", url)
     return domain_match.group(1) if domain_match else ""
 
 


### PR DESCRIPTION
Trello card [#1703](https://trello.com/c/tDRijlXn/1703-make-http-prefixes-optional-in-bulk-url-searches).