### PR TITLE
1703: Add .net to global URL search preprocessing

### DIFF
--- a/accessibility_monitoring_platform/apps/common/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_utils.py
@@ -97,6 +97,7 @@ def test_extract_domain_from_url_no_protocol():
         ("abc.co.uk", "abc"),
         ("abc.org.uk", "abc"),
         ("abc.ac.uk", "abc"),
+        ("abc.net", "abc"),
     ],
 )
 def test_sanitise_domain(domain: str, expected_result: str):

--- a/accessibility_monitoring_platform/apps/common/utils.py
+++ b/accessibility_monitoring_platform/apps/common/utils.py
@@ -49,6 +49,7 @@ def sanitise_domain(domain: str) -> str:
         ".co.uk",
         ".org.uk",
         ".ac.uk",
+        ".net",
     ]:
         if domain.endswith(suffix):
             domain = domain[: -len(suffix)]


### PR DESCRIPTION
Trello card [#1703](https://trello.com/c/tDRijlXn/1703-make-http-prefixes-optional-in-bulk-url-searches).