### PR TITLE
1759: Fix wrong asset names in 500.html

### DIFF
--- a/accessibility_monitoring_platform/templates/500.html
+++ b/accessibility_monitoring_platform/templates/500.html
@@ -13,11 +13,10 @@
     <link href="{% static 'css/init.css' %}" rel="stylesheet" media="print">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <link rel="shortcut icon" sizes="16x16 32x32 48x48" href="{% static 'assets/images/favicon.ico' %)" type="image/x-icon">
-    <link rel="mask-icon" href="{% static 'assets/images/govuk-mask-icon.svg' %}" color="#0b0c0c">
-    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'assets/images/govuk-apple-touch-icon-180x180.png' %}"/>
-    <link rel="apple-touch-icon" sizes="167x167" href="{% static 'assets/images/govuk-apple-touch-icon-167x167.png' %}"/>
-    <link rel="apple-touch-icon" sizes="152x152" href="{% static 'assets/images/govuk-apple-touch-icon-152x152.png' %}"/>
-    <link rel="apple-touch-icon" sizes="152x152" href="{% static 'assets/images/govuk-apple-touch-icon.png' %}"/>
+    <link rel="mask-icon" href="{% static 'assets/images/govuk-icon-mask.svg' %}" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="{% static 'assets/images/govuk-icon-180.png' %}"/>
+    <link rel="apple-touch-icon" sizes="192x192" href="{% static 'assets/images/govuk-icon-192.png' %}"/>
+    <link rel="apple-touch-icon" sizes="512x512" href="{% static 'assets/images/govuk-icon-512.png' %}"/>
     <meta property="og:image" content="{% static 'assets/images/govuk-opengraph-image.png' %}">
     <meta name="description" content="Accessibility Monitoring Platform">
   </head>


### PR DESCRIPTION
Trello card [#1759](https://trello.com/c/YlvQBX6N/1759-fix-500html).