### PR TITLE
1760: Equality body metadata page always Save and continues to Equality body cores

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -1353,7 +1353,10 @@ def test_platform_case_edit_redirects_based_on_button_pressed(
     "case_edit_path, expected_redirect_path",
     [
         ("cases:edit-case-close", "cases:edit-equality-body-metadata"),
-        ("cases:edit-equality-body-metadata", "cases:legacy-end-of-case"),
+        (
+            "cases:edit-equality-body-metadata",
+            "cases:list-equality-body-correspondence",
+        ),
     ],
 )
 def test_platform_update_redirects_based_on_case_variant(

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -1,4 +1,4 @@
-"""d
+"""
 Views for cases app
 """
 
@@ -1164,12 +1164,7 @@ class CaseEqualityBodyMetadataUpdateView(CaseUpdateView):
         if "save_continue" in self.request.POST:
             case: Case = self.object
             case_pk: Dict[str, int] = {"pk": case.id}
-            if case.variant == Case.Variant.ARCHIVED:
-                return reverse("cases:legacy-end-of-case", kwargs=case_pk)
-            else:
-                return reverse(
-                    "cases:list-equality-body-correspondence", kwargs=case_pk
-                )
+            return reverse("cases:list-equality-body-correspondence", kwargs=case_pk)
         return super().get_success_url()
 
 


### PR DESCRIPTION
Trello card [#1760](https://trello.com/c/z8FS63tq/1760-fix-equality-body-metadata-save-continue).