### PR TITLE
1773: Upgrade GDS Design System to 5.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^5.4.0",
+        "govuk-frontend": "^5.6.0",
         "showdown": "2.1.0"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^5.4.0",
+    "govuk-frontend": "^5.6.0",
     "showdown": "2.1.0"
   },
   "standard": {


### PR DESCRIPTION
Trello card [#1773](https://trello.com/c/VstMVv5E/1773-upgrade-gds-design-system-to-v56).