### PR TITLE
1778: Open link placeholder replaced with hyperlink when URL entered

### DIFF
--- a/__tests__/url_field_dynamic_link.spec.js
+++ b/__tests__/url_field_dynamic_link.spec.js
@@ -7,18 +7,21 @@ const linkFieldId = 'link-field-id'
 const openLinkControlId = `${linkFieldId}-open-link-control`
 
 document.body.innerHTML = `
-<input type="text"
-    name="accessibility_statement_backup_url"
-    value="${url}"
-    class="govuk-input"
-    id="${linkFieldId}">
-<a class="govuk-link govuk-link--no-visited-state amp-open-link-control"
-    id="${openLinkControlId}"
-    data-input-field-id="${linkFieldId}"
-    target="_blank"
-    href="">
-    Open link
-</a>`
+<div>
+    <input type="text"
+        name="accessibility_statement_backup_url"
+        value="${url}"
+        class="govuk-input"
+        id="${linkFieldId}">
+    <a class="govuk-link govuk-link--no-visited-state amp-open-link-control"
+        id="${openLinkControlId}"
+        data-input-field-id="${linkFieldId}"
+        target="_blank"
+        href="">
+        Open link
+    </a>
+    <span class="govuk-body-s amp-margin-bottom-0 amp-margin-left-10">Open link</span>
+ </div>`
 
 const {
   updateOpenLinkControl
@@ -33,12 +36,21 @@ describe('test common field link button functions are present', () => {
 })
 
 describe('test updateOpenLinkControl', () => {
-  test('open link control href populated with valid URL', () => {
+  test('open link control displayed and populated with url', () => {
     updateOpenLinkControl(openLinkControlId, url)
+    expect(document.getElementById(openLinkControlId).style.display).toEqual("block")
     expect(document.getElementById(openLinkControlId).href).toEqual(url)
   })
-  test('open link control href not populated with URL without https://', () => {
+  test('open link placeholder not displayed', () => {
+    updateOpenLinkControl(openLinkControlId, url)
+    expect(document.getElementById(openLinkControlId).nextElementSibling.style.display).toEqual("none")
+  })
+  test('open link control not displayed with URL without https://', () => {
     updateOpenLinkControl(openLinkControlId, 'example.com')
-    expect(document.getElementById(openLinkControlId).href).toEqual('javascript:;')
+    expect(document.getElementById(openLinkControlId).style.display).toEqual("none")
+  })
+  test('open link placeholder displayed', () => {
+    updateOpenLinkControl(openLinkControlId, 'example.com')
+    expect(document.getElementById(openLinkControlId).nextElementSibling.style.display).toEqual("block")
   })
 })

--- a/accessibility_monitoring_platform/apps/common/sitemap.py
+++ b/accessibility_monitoring_platform/apps/common/sitemap.py
@@ -1252,8 +1252,8 @@ def build_sitemap_for_current_page(
     page is case-related, otherwise return the entire sitemap.
     """
     case: Optional[Case] = current_platform_page.get_case()
-    site_map = copy.deepcopy(SITE_MAP)
     if case is not None:
+        site_map = copy.deepcopy(SITE_MAP)
         case_navigation: List[PlatformPageGroup] = [
             platform_page_group
             for platform_page_group in site_map

--- a/accessibility_monitoring_platform/apps/common/templates/common/amp_url_field_dynamic_link.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/amp_url_field_dynamic_link.html
@@ -15,4 +15,5 @@
     >
         Open link
     </a>
+    <span class="govuk-body-s amp-margin-bottom-0 amp-margin-left-10">Open link</span>
 </div>

--- a/common/static/js/url_field_dynamic_link.js
+++ b/common/static/js/url_field_dynamic_link.js
@@ -4,12 +4,13 @@ Allow user to open link entered in URL field using dynamic link
 
 function updateOpenLinkControl(openLinkControlId, value) {
   const openLinkControlElement = document.getElementById(openLinkControlId)
+  const placeholderElement = openLinkControlElement.nextElementSibling
   if (value.includes('https://') === false && value.includes('http://') === false) {
-    openLinkControlElement.classList.add('amp-open-link-control-disabled')
-    openLinkControlElement.setAttribute('href', 'javascript:;')
-    openLinkControlElement.setAttribute('target', '')
+    openLinkControlElement.style.display = "none"
+    placeholderElement.style.display = "block"
   } else {
-    openLinkControlElement.classList.remove('amp-open-link-control-disabled')
+    openLinkControlElement.style.display = "block"
+    placeholderElement.style.display = "none"
     openLinkControlElement.setAttribute('href', value)
     openLinkControlElement.setAttribute('target', '_blank')
   }

--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -431,14 +431,6 @@ img, .amp-max-width-100 {
     margin-left: 10px;
 }
 
-.amp-open-link-control-disabled {
-    pointer-events: none;
-    text-decoration: none !important;
-    cursor: default;
-    color: black !important;
-    display: block;
-}
-
 // For use in navbar
 
 .top-nav-menu {


### PR DESCRIPTION
Trello card [#1778](https://trello.com/c/NHGvf4ie/1778-dynamic-link-not-a-hyperlink).