### PR TITLE
1715: Add navigation links to Equality body correspondence page

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/equality_body_correspondence_list.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/equality_body_correspondence_list.html
@@ -31,14 +31,6 @@
             Add Zendesk ticket
         </a>
     </div>
-    <div class="govuk-grid-column-full govuk-button-group">
-        <a
-            href="{% url 'cases:edit-retest-overview' case.id %}"
-            class="govuk-link govuk-link--no-visited-state"
-        >
-            View retest overview
-        </a>
-    </div>
     <div class="govuk-grid-column-full">
         <hr class="amp-width-100 amp-margin-bottom-30" />
         {% for equality_body_correspondence in equality_body_correspondences %}
@@ -90,6 +82,20 @@
             </div>
             <hr class="amp-width-100 amp-margin-bottom-30" />
         {% endfor %}
+    </div>
+    <div class="govuk-grid-column-full govuk-button-group">
+        <a
+            href="{% url 'cases:edit-retest-overview' case.id %}"
+            class="govuk-link govuk-link--no-visited-state"
+        >
+            Continue to retest overview
+        </a>
+        <a
+            href="{% url 'cases:case-detail' case.id %}"
+            class="govuk-link govuk-link--no-visited-state"
+        >
+            Return to view case
+        </a>
     </div>
 </div>
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -3524,6 +3524,41 @@ def test_equality_body_correspondence(admin_client):
     assertContains(response, UNRESOLVED_EQUALITY_BODY_NOTES)
 
 
+def test_equality_body_correspondence_nav_links(admin_client):
+    """
+    Test equality body correspondence page contains links to to next
+    page and parent case.
+    """
+    case: Case = Case.objects.create()
+    url: str = reverse(
+        "cases:list-equality-body-correspondence", kwargs={"pk": case.id}
+    )
+
+    response: HttpResponse = admin_client.get(url)
+
+    assert response.status_code == 200
+
+    retest_overview_url: str = reverse(
+        "cases:edit-retest-overview", kwargs={"pk": case.id}
+    )
+    case_detail_url: str = reverse("cases:case-detail", kwargs={"pk": case.id})
+
+    assertContains(
+        response,
+        f"""<a href="{retest_overview_url}" class="govuk-link govuk-link--no-visited-state">
+            Continue to retest overview
+        </a>""",
+        html=True,
+    )
+    assertContains(
+        response,
+        f"""<a href="{case_detail_url}" class="govuk-link govuk-link--no-visited-state">
+            Return to view case
+        </a>""",
+        html=True,
+    )
+
+
 def test_equality_body_correspondence_status_toggle(admin_client):
     """
     Test equality body correspondence page buttons toggles the status


### PR DESCRIPTION
Trello card [#1715](https://trello.com/c/oPctTcUn/1715-add-continue-page-button-in-ehrc-zendesk-tickets).