### PR TITLE
1792: Show other pages' retest notes for copying

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
@@ -46,6 +46,31 @@
                                     <span class="govuk-details__summary-text">Additional issues found on page</span>
                                 </summary>
                                 <div class="govuk-details__text">
+                                    {% if other_pages_with_retest_notes %}
+                                        <details class="govuk-details" data-module="govuk-details">
+                                            <summary class="govuk-details__summary">
+                                                <span class="govuk-details__summary-text">
+                                                    Other additional issues
+                                                </span>
+                                            </summary>
+                                            <div class="govuk-details__text">
+                                                <ul class="govuk-list govuk-list--bullet amp-margin-bottom-10">
+                                                {% for other_page in other_pages_with_retest_notes %}
+                                                    <li>
+                                                        <b>{{ other_page }}</b>
+                                                        <textarea id="{{ form.retest_notes.auto_id }}-{{ forloop.counter }}" hidden>{{ other_page.retest_notes }}</textarea>
+                                                        <span tabIndex="0"
+                                                            class="amp-control amp-copy-error"
+                                                            sourceId="{{ form.retest_notes.auto_id }}-{{ forloop.counter }}"
+                                                            targetId="{{ form.retest_notes.auto_id }}">
+                                                            Click to populate additional issues</span>
+                                                        {{ other_page.retest_notes|markdown_to_html }}
+                                                    </li>
+                                                {% endfor %}
+                                                </ul>
+                                            </div>
+                                        </details>
+                                    {% endif %}
                                     {% include 'common/amp_field.html' with field=form.retest_notes %}
                                 </div>
                             </details>

--- a/accessibility_monitoring_platform/apps/audits/utils.py
+++ b/accessibility_monitoring_platform/apps/audits/utils.py
@@ -931,3 +931,13 @@ def get_next_equality_body_retest_page_url(
     current_page_position: int = retest_pages.index(current_page)
     next_page_pk: Dict[str, int] = {"pk": retest_pages[current_page_position + 1].id}
     return reverse("audits:edit-retest-page-checks", kwargs=next_page_pk)
+
+
+def get_other_pages_with_retest_notes(page: Page) -> List[Page]:
+    """Check other pages of this case for retest notes and return them"""
+    audit: Audit = page.audit
+    return [
+        other_page
+        for other_page in audit.testable_pages
+        if other_page.retest_notes and other_page != page
+    ]

--- a/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
+++ b/accessibility_monitoring_platform/apps/audits/views/twelve_week.py
@@ -47,7 +47,11 @@ from ..models import (
     StatementCheckResult,
     StatementPage,
 )
-from ..utils import get_next_retest_page_url, get_twelve_week_test_view_sections
+from ..utils import (
+    get_next_retest_page_url,
+    get_other_pages_with_retest_notes,
+    get_twelve_week_test_view_sections,
+)
 from .base import (
     AuditCaseComplianceUpdateView,
     AuditUpdateView,
@@ -196,6 +200,9 @@ class AuditRetestPageChecksFormView(AuditPageChecksFormView):
 
         context["check_results_formset"] = check_results_formset
         context["check_results_and_forms"] = check_results_and_forms
+        context["other_pages_with_retest_notes"] = get_other_pages_with_retest_notes(
+            page=self.page
+        )
 
         return context
 


### PR DESCRIPTION
Trello card [#1792](https://trello.com/c/KVcZ3bQ7/1792-matching-errors-link-for-additional-issues-found-on-page).