### PR TITLE
v0.6.124 - Swap order of fields on **Edit PSB Zendesk ticket** page

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/forms.py
+++ b/accessibility_monitoring_platform/apps/cases/forms.py
@@ -1026,9 +1026,9 @@ class ZendeskTicketCreateUpdateForm(forms.ModelForm):
     Form for updating a zendesk ticket
     """
 
-    url = AMPURLField(label="Link to Zendesk ticket")
     summary = AMPTextField(label="Summary")
+    url = AMPURLField(label="Link to Zendesk ticket")
 
     class Meta:
         model = ZendeskTicket
-        fields = ["url", "summary"]
+        fields = ["summary", "url"]

--- a/stack_tests/smoke_tests/cypress/e2e/case.cy.js
+++ b/stack_tests/smoke_tests/cypress/e2e/case.cy.js
@@ -23,7 +23,7 @@ describe('View case', () => {
     cy.contains(/^Case$/).click()
 
     cy.get('[id="edit-qa-comments"]').click()
-    cy.title().should('eq', `${organisationName} | QA comments`)
+    cy.title().should('eq', `${organisationName} | Comments (2)`)
     cy.contains(/^Case$/).click()
 
     cy.get('[id="edit-qa-approval"]').click()


### PR DESCRIPTION
* Swap order of fields on **Edit PSB Zendesk ticket** page ([example](https://platform.accessibility-monitoring.service.gov.uk/cases/3503/update-zendesk-ticket/)) [#1798](https://trello.com/c/Dg7w2NqX/1798-change-field-order-on-edit-psb-zendesk-ticket-page)