### PR TITLE
1816: Restore hide fixed button to 12-week retest summary pages

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_test_summary.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/retest_test_summary.html
@@ -1,27 +1,20 @@
 {% extends 'common/case_form.html' %}
 
 {% block preform %}
-    {% if show_failures_by_page %}
-        <form method="get" action="{% url 'audits:edit-audit-retest-wcag-summary' audit.id %}">
-            <input
-                type="submit"
-                value="WCAG view"
-                name="view"
-                class="govuk-button govuk-button--secondary"
-                data-module="govuk-button"
-            />
-        </form>
-    {% else %}
-        <form method="get" action="{% url 'audits:edit-audit-retest-wcag-summary' audit.id %}">
-            <input
-                type="submit"
-                value="Page view"
-                name="view"
-                class="govuk-button govuk-button--secondary"
-                data-module="govuk-button"
-            />
-        </form>
-    {% endif %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-button-group">
+            {% if show_failures_by_page %}
+                <a href="?wcag-view=true{% if hide_fixed %}&hide-fixed=true{% endif %}" class="govuk-button govuk-button--secondary">WCAG view</a>
+            {% else %}
+                <a href="?page-view=true{% if hide_fixed %}&hide-fixed=true{% endif %}" class="govuk-button govuk-button--secondary">Page view</a>
+            {% endif %}
+            {% if hide_fixed %}
+                <a href="?show-all=true{% if show_failures_by_page %}&page-view=true{% endif %}" class="govuk-button govuk-button--secondary">Show all</a>
+            {% else %}
+                <a href="?hide-fixed=true{% if show_failures_by_page %}&page-view=true{% endif %}" class="govuk-button govuk-button--secondary">Hide fixed</a>
+            {% endif %}
+        </div>
+    </div>
     {% if show_failures_by_page %}
         <h2 class="govuk-heading-l">{{ sitemap.current_platform_page.get_name }} | Page view</h2>
         {% for page, failures in audit_failures_by_page.items %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/test_summary.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/test_summary.html
@@ -1,27 +1,15 @@
 {% extends 'common/case_form.html' %}
 
 {% block preform %}
-    {% if show_failures_by_page %}
-        <form method="get" action="{% url 'audits:edit-audit-wcag-summary' audit.id %}">
-            <input
-                type="submit"
-                value="WCAG view"
-                name="view"
-                class="govuk-button govuk-button--secondary"
-                data-module="govuk-button"
-            />
-        </form>
-    {% else %}
-        <form method="get" action="{% url 'audits:edit-audit-wcag-summary' audit.id %}">
-            <input
-                type="submit"
-                value="Page view"
-                name="view"
-                class="govuk-button govuk-button--secondary"
-                data-module="govuk-button"
-            />
-        </form>
-    {% endif %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-button-group">
+            {% if show_failures_by_page %}
+                <a href="?wcag-view=true" class="govuk-button govuk-button--secondary">WCAG view</a>
+            {% else %}
+                <a href="?page-view=true" class="govuk-button govuk-button--secondary">Page view</a>
+            {% endif %}
+        </div>
+    </div>
     {% if show_failures_by_page %}
         <h2 class="govuk-heading-l">{{ sitemap.current_platform_page.get_name }} | Page view</h2>
         {% for page, failures in audit_failures_by_page.items %}

--- a/accessibility_monitoring_platform/apps/audits/views/initial.py
+++ b/accessibility_monitoring_platform/apps/audits/views/initial.py
@@ -369,8 +369,7 @@ class AuditSummaryUpdateView(AuditUpdateView):
         context: dict[str, Any] = super().get_context_data(**kwargs)
         audit: Audit = self.object
 
-        view_url_param: str | None = self.request.GET.get("view")
-        show_failures_by_page: bool = view_url_param == "Page view"
+        show_failures_by_page: bool = "page-view" in self.request.GET
         context["show_failures_by_page"] = show_failures_by_page
 
         if show_failures_by_page:


### PR DESCRIPTION
Trello card [#1816](https://trello.com/c/GgQKTaQ8/1816-add-hide-fixed-to-test-summary-pages).