### PR TITLE
1813: Don't use default overdue link on View case page

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/overview.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/overview.html
@@ -27,7 +27,7 @@
     </p>
     <h2 class="govuk-heading-s amp-margin-bottom-5">Overdue</h2>
     <p class="govuk-body-m amp-margin-bottom-10">
-        {% if case.overdue_link %}
+        {% if case.overdue_link and case.overdue_link.label != "Go to case" %}
             <a href="{{ case.overdue_link.url }}" class="govuk-link govuk-link--no-visited-state">
                 {{ case.overdue_link.label }}
             </a>


### PR DESCRIPTION
Trello card [#1813](https://trello.com/b/7qRdnJ8t/building-tools-to-facilitate-manual-testing).