### PR TITLE
1830: Add links to equality body retests to Case nav

### DIFF
--- a/accessibility_monitoring_platform/apps/common/sitemap.py
+++ b/accessibility_monitoring_platform/apps/common/sitemap.py
@@ -1040,6 +1040,7 @@ SITE_MAP: list[PlatformPageGroup] = [
                 subpages=[
                     EqualityBodyRetestPlatformPage(
                         name="Retest #{object.id_within_case}",
+                        url_name="audits:retest-metadata-update",
                         subpages=[
                             EqualityBodyRetestPlatformPage(
                                 name="Retest metadata",


### PR DESCRIPTION
Trello card [#1830](https://trello.com/c/Vq8njGEF/1830-fixed-retest-links-under-post-case-section).