### PR TITLE
1829: Hide pages with no initial errors from retest UI

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_pages.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_pages.html
@@ -2,18 +2,20 @@
 
 {% block preform %}
 {% for page in case.audit.testable_pages %}
-    <h2 class="govuk-heading-m">{{ page }}</h2>
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <div class="govuk-form-group">
-                <label class="govuk-label"><b>URL</b></label>
-                <div class="govuk-hint">{{ page.url }}</div>
-            </div>
-            <div class="govuk-form-group">
-                <label class="govuk-label"><b>Page location description if single page app</b></label>
-                <div class="govuk-hint">{% if page.location %}{{ page.location }}{% else %}None{% endif %}</div>
+    {% if page.failed_check_results.count > 0 %}
+        <h2 class="govuk-heading-m">{{ page }}</h2>
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-full">
+                <div class="govuk-form-group">
+                    <label class="govuk-label"><b>URL</b></label>
+                    <div class="govuk-hint">{{ page.url }}</div>
+                </div>
+                <div class="govuk-form-group">
+                    <label class="govuk-label"><b>Page location description if single page app</b></label>
+                    <div class="govuk-hint">{% if page.location %}{{ page.location }}{% else %}None{% endif %}</div>
+                </div>
             </div>
         </div>
-    </div>
+    {% endif %}
 {% endfor %}
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/common/sitemap.py
+++ b/accessibility_monitoring_platform/apps/common/sitemap.py
@@ -331,12 +331,13 @@ class AuditRetestPagesPlatformPage(AuditPlatformPage):
             if self.subpages is not None:
                 subpage_instances: list[PlatformPage] = []
                 for page in case.audit.testable_pages:
-                    for subpage in self.subpages:
-                        if subpage.object_class == Page:
-                            subpage_instance: PlatformPage = copy.copy(subpage)
-                            subpage_instance.object = page
-                            subpage_instance.populate_subpage_objects()
-                            subpage_instances.append(subpage_instance)
+                    if page.failed_check_results.count() > 0:
+                        for subpage in self.subpages:
+                            if subpage.object_class == Page:
+                                subpage_instance: PlatformPage = copy.copy(subpage)
+                                subpage_instance.object = page
+                                subpage_instance.populate_subpage_objects()
+                                subpage_instances.append(subpage_instance)
                 self.subpages = subpage_instances
 
 

--- a/accessibility_monitoring_platform/apps/common/tests/test_sitemap.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_sitemap.py
@@ -10,7 +10,14 @@ from django.http import HttpRequest, HttpResponse
 from django.urls import reverse
 from pytest_django.asserts import assertContains
 
-from ...audits.models import Audit, Page, Retest, RetestPage
+from ...audits.models import (
+    Audit,
+    CheckResult,
+    Page,
+    Retest,
+    RetestPage,
+    WcagDefinition,
+)
 from ...cases.models import Case, Contact, EqualityBodyCorrespondence, ZendeskTicket
 from ...comments.models import Comment
 from ...common.models import EmailTemplate
@@ -462,8 +469,23 @@ def test_audit_retest_pages_platform_page():
 
     case: Case = Case.objects.create()
     audit: Audit = Audit.objects.create(case=case)
-    Page.objects.create(audit=audit, name="Page one", url="url")
-    Page.objects.create(audit=audit, name="Page two", url="url")
+    page_1: Page = Page.objects.create(audit=audit, name="Page one", url="url")
+    page_2: Page = Page.objects.create(audit=audit, name="Page two", url="url")
+    wcag_definition: WcagDefinition = WcagDefinition.objects.create(
+        type=WcagDefinition.Type.AXE
+    )
+    CheckResult.objects.create(
+        audit=audit,
+        page=page_1,
+        wcag_definition=wcag_definition,
+        check_result_state=CheckResult.Result.ERROR,
+    )
+    CheckResult.objects.create(
+        audit=audit,
+        page=page_2,
+        wcag_definition=wcag_definition,
+        check_result_state=CheckResult.Result.ERROR,
+    )
 
     audit_retest_pages_platform_page.populate_from_case(case=case)
 


### PR DESCRIPTION
Trello card [#1829](https://trello.com/c/tZpEUKB8/1829-empty-12-week-retest-causes-500-error-after-pressing-save-and-continue).