### PR TITLE
1861: Restore back to top link removed in error

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/page_checks.html
@@ -88,7 +88,12 @@
         </div>
     {% endfor %}
 </form>
-{% include 'common/back_to_top.html' %}
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-full govuk-body">
+        <hr class="amp-width-100 amp-margin-bottom-30">
+        {% include 'common/back_to_top.html' %}
+    </div>
+</div>
 {% endblock %}
 
 {% block extrascript %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
@@ -127,6 +127,12 @@
             </div>
         {% endfor %}
     </form>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full govuk-body">
+            <hr class="amp-width-100 amp-margin-bottom-30">
+            {% include 'common/back_to_top.html' %}
+        </div>
+    </div>
 {% endblock %}
 
 {% block extrascript %}

--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -3561,3 +3561,28 @@ def test_nav_details_subpage_renders(admin_client):
         </ul>""",
         html=True,
     )
+
+
+@pytest.mark.parametrize(
+    "path_name",
+    [
+        "audits:edit-audit-page-checks",
+        "audits:edit-audit-retest-page-checks",
+    ],
+)
+def test_tall_results_page_has_back_to_top_link(path_name, admin_client):
+    """Test that tall pages include a back to top link"""
+    case: Case = Case.objects.create()
+    audit: Audit = Audit.objects.create(case=case)
+    page: Page = Page.objects.create(audit=audit)
+    page_pk: dict[str, int] = {"pk": page.id}
+
+    response: HttpResponse = admin_client.get(reverse(path_name, kwargs=page_pk))
+
+    assert response.status_code == 200
+
+    assertContains(
+        response,
+        '<a href="#" class="govuk-link govuk-link--no-visited-state">Back to top</a>',
+        html=True,
+    )


### PR DESCRIPTION
Trello card [#1861](https://trello.com/c/ZyGhCXT2/1861-restore-missing-back-to-top-link).