### PR TITLE
1869: Show error summary only once for each form with errors

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/equality_body_retest_page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/equality_body_retest_page_checks.html
@@ -94,7 +94,8 @@
                             {% endif %}
                         </div>
                     </div>
-                    {% include 'common/error_summary.html' with formset=retest_check_results_formset %}
+                    {% include 'common/formset_error_summary.html' with formset=retest_check_results_formset %}
+                    {% include 'common/error_summary.html' %}
                     {% csrf_token %}
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/equality_body_retest_statement_pages_formset.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/equality_body_retest_statement_pages_formset.html
@@ -22,7 +22,8 @@
                 {% include 'audits/helpers/equality_body_retest_nav_steps.html' with current_page='audits:edit-equality-body-statement-pages' %}
             </div>
             <div class="govuk-grid-column-two-thirds">
-                {% include 'common/error_summary.html' with formset=statement_pages_formset %}
+                {% include 'common/formset_error_summary.html' with formset=statement_pages_formset %}
+                {% include 'common/error_summary.html' %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-pages' retest.id %}">
                     {% csrf_token %}
                     {{ statement_pages_formset.management_form }}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/page_checks.html
@@ -43,7 +43,7 @@
             {% endif %}
         </div>
     </div>
-    {% include 'common/error_summary.html' with formset=check_results_formset %}
+    {% include 'common/formset_error_summary.html' with formset=check_results_formset %}
     {% csrf_token %}
     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/pages.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/pages.html
@@ -1,25 +1,14 @@
 {% extends 'common/case_form.html' %}
 
 {% block preform %}
-{% if standard_pages_formset.errors %}
-    {% for form in standard_pages_formset.forms %}
-        {% if form.errors %}
-            {% include 'common/error_summary.html' %}
-        {% endif %}
-    {% endfor %}
-{% endif %}
-{% if extra_pages_formset.errors %}
-    {% for form in extra_pages_formset.forms %}
-        {% if form.errors %}
-            {% include 'common/error_summary.html' %}
-        {% endif %}
-    {% endfor %}
-{% endif %}
+{% include 'common/formset_error_summary.html' with formset=standard_pages_formset %}
+{% include 'common/formset_error_summary.html' with formset=extra_pages_formset %}
 {% endblock %}
 
 {% block form %}
 <form method="post" action="{% url 'audits:edit-audit-pages' audit.id %}">
     {% csrf_token %}
+    {% include 'common/form_errors.html' with errors=form.non_field_errors %}
     {{ standard_pages_formset.management_form }}
     {{ extra_pages_formset.management_form }}
 

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_pages_formset.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/statement_pages_formset.html
@@ -2,7 +2,7 @@
 
 {% block form %}
     {% include "cases/helpers/messages.html" %}
-    {% include 'common/error_summary.html' with formset=statement_pages_formset %}
+    {% include 'common/formset_error_summary.html' with formset=statement_pages_formset %}
     <form method="post" action="{% url 'audits:edit-statement-pages' audit.id %}">
         {% csrf_token %}
         {{ statement_pages_formset.management_form }}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_retest_page_checks.html
@@ -80,7 +80,7 @@
                 {% endif %}
             </div>
         </div>
-        {% include 'common/error_summary.html' with formset=check_results_formset %}
+        {% include 'common/formset_error_summary.html' with formset=check_results_formset %}
         {% csrf_token %}
         {% include 'common/form_errors.html' with errors=form.non_field_errors %}
         {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_statement_pages_formset.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/twelve_week_statement_pages_formset.html
@@ -1,7 +1,7 @@
 {% extends 'common/case_form.html' %}
 
 {% block form %}
-    {% include 'common/error_summary.html' with formset=statement_pages_formset %}
+    {% include 'common/formset_error_summary.html' with formset=statement_pages_formset %}
     <form method="post" action="{% url 'audits:edit-audit-retest-statement-pages' audit.id %}">
         {% csrf_token %}
         {{ statement_pages_formset.management_form }}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_compliance.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_compliance.html
@@ -24,7 +24,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 {% include 'audits/helpers/statement_pages_eb_retest.html' with audit=retest.case.audit  %}
-                {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+                {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-compliance' retest.id %}">
                     {% csrf_token %}
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_custom.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_custom.html
@@ -24,7 +24,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 {% include 'audits/helpers/statement_pages_eb_retest.html' with audit=retest.case.audit  %}
-                {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+                {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-custom' retest.id %}">
                     {% csrf_token %}
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_feedback.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_feedback.html
@@ -24,7 +24,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 {% include 'audits/helpers/statement_pages_eb_retest.html' with audit=retest.case.audit  %}
-                {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+                {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-feedback' retest.id %}">
                     {% csrf_token %}
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_non_accessible.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_non_accessible.html
@@ -24,7 +24,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 {% include 'audits/helpers/statement_pages_eb_retest.html' with audit=retest.case.audit  %}
-                {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+                {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-non-accessible' retest.id %}">
                     {% csrf_token %}
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_overview.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_overview.html
@@ -24,7 +24,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 {% include 'audits/helpers/statement_pages_eb_retest.html' with audit=retest.case.audit  %}
-                {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+                {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-overview' retest.id %}">
                     {% csrf_token %}
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_preparation.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_preparation.html
@@ -24,7 +24,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 {% include 'audits/helpers/statement_pages_eb_retest.html' with audit=retest.case.audit  %}
-                {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+                {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-preparation' retest.id %}">
                     {% csrf_token %}
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_website.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/equality_body_retest_statement_website.html
@@ -24,7 +24,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 {% include 'audits/helpers/statement_pages_eb_retest.html' with audit=retest.case.audit  %}
-                {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+                {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
                 <form method="post" action="{% url 'audits:edit-equality-body-statement-website' retest.id %}">
                     {% csrf_token %}
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/retest_statement_formset_form.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/retest_statement_formset_form.html
@@ -2,12 +2,13 @@
 
 {% block preform %}
     {% include 'audits/helpers/statement_pages_twelve_week.html' %}
-    {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+    {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
 {% endblock %}
 
 {% block form %}
     <form method="post" action="{% url sitemap.current_platform_page.url_name audit.id %}">
         {% csrf_token %}
+        {% include 'common/form_errors.html' with errors=form.non_field_errors %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 {% include 'audits/helpers/retest_statement_check_formset.html' %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/retest_statement_other.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/retest_statement_other.html
@@ -2,7 +2,7 @@
 
 {% block preform %}
     {% include 'audits/helpers/statement_pages_twelve_week.html' %}
-    {% include 'common/error_summary.html' with formset=retest_statement_check_results_formset %}
+    {% include 'common/formset_error_summary.html' with formset=retest_statement_check_results_formset %}
     {% if not retest_statement_check_results_formset.forms %}
         <p class="govuk-body">No custom statement issues found in initial test.</p>
     {% endif %}
@@ -11,6 +11,7 @@
 {% block form %}
     <form method="post" action="{% url sitemap.current_platform_page.url_name audit.id %}">
         {% csrf_token %}
+        {% include 'common/form_errors.html' with errors=form.non_field_errors %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 {% include 'audits/helpers/retest_statement_check_formset.html' %}

--- a/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/statement_formset_form.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/statement_checks/statement_formset_form.html
@@ -1,7 +1,7 @@
 {% extends 'common/case_form.html' %}
 
 {% block preform %}
-    {% include 'common/error_summary.html' with formset=statement_check_results_formset %}
+    {% include 'common/formset_error_summary.html' with formset=statement_check_results_formset %}
     {% include 'audits/helpers/statement_pages.html' %}
 {% endblock %}
 

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/forms/contact_create.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/forms/contact_create.html
@@ -7,6 +7,7 @@
 {% block form %}
 <form method="post" action="{% url sitemap.current_platform_page.url_name case.id %}">
     {% csrf_token %}
+    {% include 'common/form_errors.html' with errors=form.non_field_errors %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% include 'common/amp_form_snippet.html' %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/outstanding_issues.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/outstanding_issues.html
@@ -1,8 +1,5 @@
 {% extends 'common/case_form.html' %}
 
-{% block form %}
-{% endblock %}
-
 {% block preform %}
 {% if case.audit %}
     {% include 'audits/helpers/test_summary.html' %}
@@ -19,4 +16,7 @@
         before using this page.
     </p>
 {% endif %}
+{% endblock %}
+
+{% block form %}
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/status_workflow.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/status_workflow.html
@@ -1,10 +1,6 @@
 {% extends 'common/case_form.html' %}
 
-{% block form %}
-{% endblock %}
-
 {% block preform %}
-
 <h2 class="govuk-heading-s amp-margin-bottom-5">Status summary</h2>
 <ul class="govuk-list govuk-list--bullet">
     <li>
@@ -232,4 +228,7 @@
         {% if case.enforcement_correspondence_complete_date %}&check;{% endif %}
     </li>
 </ul>
+{% endblock %}
+
+{% block form %}
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/common/templates/common/contact_admin.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/contact_admin.html
@@ -14,15 +14,14 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <h1 class="govuk-heading-xl amp-margin-bottom-15">{{ sitemap.current_platform_page.get_name }}</h1>
+                {% include 'common/error_summary.html' %}
             </div>
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <form method="post" action="{% url 'common:contact-admin' %}">
                     {% csrf_token %}
-
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
-
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
 
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/common/templates/common/error_summary.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/error_summary.html
@@ -1,25 +1,10 @@
-{% if form.errors or formset.errors or formset.non_form_errors %}
+{% if form.errors %}
     <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
         <h2 class="govuk-error-summary__title" id="error-summary-title">
             There is a problem
         </h2>
         <div class="govuk-error-summary__body">
             <ul class="govuk-list govuk-error-summary__list">
-                {% for error in formset.non_form_errors %}
-                    <li class="govuk-error-message">{{ error }}</li>
-                {% endfor %}
-                {% for form in formset %}
-                    {% for error in form.non_field_errors %}
-                        <li class="govuk-error-message">{{ error }}</li>
-                    {% endfor %}
-                    {% for field in form.visible_fields %}
-                        {% for error in field.errors%}
-                            <li>
-                                <a href="#{{ field.auto_id }}-label">{{ error }}</a>
-                            </li>
-                        {% endfor %}
-                    {% endfor %}
-                {% endfor%}
                 {% for error in form.non_field_errors %}
                     <li class="govuk-error-message">{{ error }}</li>
                 {% endfor %}

--- a/accessibility_monitoring_platform/apps/common/templates/common/formset_error_summary.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/formset_error_summary.html
@@ -1,0 +1,3 @@
+{% for form in formset.forms %}
+    {% include 'common/error_summary.html' %}
+{% endfor %}

--- a/accessibility_monitoring_platform/apps/common/templates/common/issue_report.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/issue_report.html
@@ -16,15 +16,14 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <h1 class="govuk-heading-xl amp-margin-bottom-15">{{ sitemap.current_platform_page.get_name }}</h1>
+                {% include 'common/error_summary.html' %}
             </div>
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <form method="post" action="{% url 'common:issue-report' %}">
                     {% csrf_token %}
-
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
-
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
 
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/common/templates/common/platform_checking.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/platform_checking.html
@@ -18,6 +18,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <h1 class="govuk-heading-xl amp-margin-bottom-15">{{ sitemap.current_platform_page.get_name }}</h1>
+                {% include 'common/error_summary.html' %}
             </div>
         </div>
         <div class="govuk-grid-row">
@@ -25,9 +26,7 @@
                 <h2 class="govuk-heading-m">Write to log</h2>
                 <form method="post" action="{% url 'common:platform-checking' %}">
                     {% csrf_token %}
-
                     {% include 'common/form_errors.html' with errors=form.non_field_errors %}
-
                     {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
 
                     <div class="govuk-grid-row">

--- a/accessibility_monitoring_platform/apps/common/templates/common/settings/edit_footer_links.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/settings/edit_footer_links.html
@@ -1,4 +1,3 @@
-
 {% extends 'base.html' %}
 
 {% load l10n %}
@@ -15,7 +14,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 <h1 class="govuk-heading-xl amp-margin-bottom-15">{{ sitemap.current_platform_page.get_name }}</h1>
-                {% include 'common/error_summary.html' with formset=links_formset %}
+                {% include 'common/formset_error_summary.html' with formset=links_formset %}
                 <form method="post" action="{% url 'common:edit-footer-links' %}">
                     {% csrf_token %}
                     {{ links_formset.management_form }}

--- a/accessibility_monitoring_platform/apps/common/templates/common/settings/edit_frequently_used_links.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/settings/edit_frequently_used_links.html
@@ -14,7 +14,7 @@
             </div>
             <div class="govuk-grid-column-two-thirds">
                 <h1 class="govuk-heading-xl amp-margin-bottom-15">{{ sitemap.current_platform_page.get_name }}</h1>
-                {% include 'common/error_summary.html' with formset=links_formset %}
+                {% include 'common/formset_error_summary.html' with formset=links_formset %}
                 <form method="post" action="{% url 'common:edit-frequently-used-links' %}">
                     {% csrf_token %}
                     {{ links_formset.management_form }}

--- a/accessibility_monitoring_platform/apps/notifications/templates/notifications/reminder_task_create.html
+++ b/accessibility_monitoring_platform/apps/notifications/templates/notifications/reminder_task_create.html
@@ -3,6 +3,7 @@
 {% block form %}
     <form method="post" action="{% url sitemap.current_platform_page.url_name case.id %}">
     {% csrf_token %}
+    {% include 'common/form_errors.html' with errors=form.non_field_errors %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% include 'common/amp_form_snippet.html' %}

--- a/accessibility_monitoring_platform/apps/notifications/templates/notifications/reminder_task_update.html
+++ b/accessibility_monitoring_platform/apps/notifications/templates/notifications/reminder_task_update.html
@@ -3,6 +3,7 @@
 {% block form %}
     <form method="post" action="{% url 'notifications:edit-reminder-task' task.id %}">
         {% csrf_token %}
+        {% include 'common/form_errors.html' with errors=form.non_field_errors %}
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 {% include 'common/amp_form_snippet.html' %}


### PR DESCRIPTION
Trello card [#1869](https://trello.com/c/mjilj7cN/1869-suppress-multiple-error-messages-in-form-sets).