### PR TITLE
v0.6.151 - Show both next pages on Unresponsive PSB page

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/cases/tests/test_views.py
@@ -4087,6 +4087,8 @@ def test_add_contact_details_redirects_correctly(admin_client):
     [
         ("edit-case-metadata", "Initial test | Testing details"),
         ("manage-contact-details", "Report correspondence | Report sent on"),
+        ("edit-no-psb-response", "Report correspondence | Report sent on"),
+        ("edit-no-psb-response", "Closing the case | Recommendation"),
         ("edit-12-week-update-request-ack", "Closing the case | Reviewing changes"),
         ("edit-case-close", "Post case | Statement enforcement"),
     ],

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -605,6 +605,20 @@ class CaseNoPSBResponseUpdateView(CaseUpdateView):
         )
         return get_platform_page_by_url_name(url_name=next_page_url_name, instance=case)
 
+    def get_context_data(self, **kwargs: dict[str, Any]) -> dict[str, Any]:
+        """Get context data for template rendering"""
+        context: dict[str, Any] = super().get_context_data(**kwargs)
+        case: Case = self.object
+        context["next_platform_pages"] = [
+            get_platform_page_by_url_name(
+                url_name="cases:edit-report-sent-on", instance=case
+            ),
+            get_platform_page_by_url_name(
+                url_name="cases:edit-enforcement-recommendation", instance=case
+            ),
+        ]
+        return context
+
 
 class CaseReportSentOnUpdateView(CaseUpdateView):
     """

--- a/accessibility_monitoring_platform/apps/common/templates/common/next_platform_page.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/next_platform_page.html
@@ -4,7 +4,7 @@
             Next:
             {% if next_platform_pages %}
                 {% for next_platform_page in next_platform_pages %}
-                    {% if forloop.counter > 1 %}or{% endif %}
+                    {% if forloop.counter > 1 %}<br>or{% endif %}
                     <b>{{ next_platform_page.platform_page_group_name }} |
                     {{ next_platform_page.get_name }}</b>
                 {% endfor %}


### PR DESCRIPTION
* Show both next pages on Unresponsive PSB page ([example](https://platform.accessibility-monitoring.service.gov.uk/cases/1951/edit-no-psb-response/)) [#1873](https://trello.com/c/chzfFqhx/1873-show-both-next-pages-for-unresponsive-psb)