### PR TITLE
1895: Use reporting instead of testing complete date

### DIFF
--- a/accessibility_monitoring_platform/apps/common/metrics.py
+++ b/accessibility_monitoring_platform/apps/common/metrics.py
@@ -1,4 +1,4 @@
-""" Utility functions for calculating metrics and charts """
+"""Utility functions for calculating metrics and charts"""
 
 from collections import OrderedDict
 from dataclasses import dataclass
@@ -219,12 +219,12 @@ def get_case_progress_metrics() -> list[ThirtyDayMetric]:
         ThirtyDayMetric(
             label="Tests completed",
             last_30_day_count=Case.objects.filter(
-                testing_details_complete_date__gte=thirty_days_ago
+                reporting_details_complete_date__gte=thirty_days_ago
             ).count(),
             previous_30_day_count=Case.objects.filter(
-                testing_details_complete_date__gte=sixty_days_ago
+                reporting_details_complete_date__gte=sixty_days_ago
             )
-            .filter(testing_details_complete_date__lt=thirty_days_ago)
+            .filter(reporting_details_complete_date__lt=thirty_days_ago)
             .count(),
         ),
         ThirtyDayMetric(
@@ -258,7 +258,7 @@ def get_case_yearly_metrics() -> list[YearlyMetric]:
     start_date: datetime = get_first_of_this_month_last_year()
     for label, date_column_name in [
         ("Cases created", "created"),
-        ("Tests completed", "testing_details_complete_date"),
+        ("Tests completed", "reporting_details_complete_date"),
         ("Reports sent", "report_sent_date"),
         ("Cases completed", "completed_date"),
     ]:

--- a/accessibility_monitoring_platform/apps/common/tests/test_metrics.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_metrics.py
@@ -321,25 +321,25 @@ def test_get_case_progress_metrics(mock_date):
 
     Case.objects.create(
         created=datetime(2021, 11, 5, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         completed_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
     )
     Case.objects.create(
         created=datetime(2021, 12, 5, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         completed_date=datetime(2021, 12, 5, tzinfo=timezone.utc),
     )
     Case.objects.create(
         created=datetime(2021, 12, 6, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2021, 12, 6, tzinfo=timezone.utc),
         completed_date=datetime(2021, 12, 6, tzinfo=timezone.utc),
     )
     Case.objects.create(
         created=datetime(2022, 1, 1, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2021, 12, 6, tzinfo=timezone.utc),
         completed_date=datetime(2021, 12, 16, tzinfo=timezone.utc),
     )
@@ -371,25 +371,25 @@ def test_get_case_yearly_metrics(mock_datetime):
 
     Case.objects.create(
         created=datetime(2021, 11, 5, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         completed_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
     )
     Case.objects.create(
         created=datetime(2021, 12, 5, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         completed_date=datetime(2021, 12, 5, tzinfo=timezone.utc),
     )
     Case.objects.create(
         created=datetime(2021, 12, 6, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2021, 12, 6, tzinfo=timezone.utc),
         completed_date=datetime(2021, 12, 6, tzinfo=timezone.utc),
     )
     Case.objects.create(
         created=datetime(2022, 1, 1, tzinfo=timezone.utc),
-        testing_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
+        reporting_details_complete_date=datetime(2022, 1, 1, tzinfo=timezone.utc),
         report_sent_date=datetime(2021, 12, 6, tzinfo=timezone.utc),
         completed_date=datetime(2021, 12, 16, tzinfo=timezone.utc),
     )

--- a/accessibility_monitoring_platform/apps/common/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_views.py
@@ -311,7 +311,7 @@ def test_issue_report_link(prototype_name, issue_report_link_expected, admin_cli
     "case_field, metric_id, lowercase_label",
     [
         ("created", "cases-created", "cases created"),
-        ("testing_details_complete_date", "tests-completed", "tests completed"),
+        ("reporting_details_complete_date", "tests-completed", "tests completed"),
         ("report_sent_date", "reports-sent", "reports sent"),
         ("completed_date", "cases-closed", "cases closed"),
     ],
@@ -353,7 +353,7 @@ def test_case_progress_metric_over(
     "case_field, metric_id, lowercase_label",
     [
         ("created", "cases-created", "cases created"),
-        ("testing_details_complete_date", "tests-completed", "tests completed"),
+        ("reporting_details_complete_date", "tests-completed", "tests completed"),
         ("report_sent_date", "reports-sent", "reports sent"),
         ("completed_date", "cases-closed", "cases closed"),
     ],
@@ -398,7 +398,7 @@ def test_case_progress_metric_under(
         (
             "Tests completed",
             "tests-completed-over-the-last-year",
-            "testing_details_complete_date",
+            "reporting_details_complete_date",
         ),
         ("Reports sent", "reports-sent-over-the-last-year", "report_sent_date"),
         ("Cases completed", "cases-completed-over-the-last-year", "completed_date"),

--- a/accessibility_monitoring_platform/apps/exports/csv_export_utils.py
+++ b/accessibility_monitoring_platform/apps/exports/csv_export_utils.py
@@ -387,7 +387,7 @@ CASE_COLUMNS_FOR_EXPORT: list[CSVColumn] = [
     CSVColumn(
         column_header="Testing details page complete",
         source_class=Case,
-        source_attr="testing_details_complete_date",
+        source_attr="reporting_details_complete_date",
     ),
     CSVColumn(
         column_header="Link to report draft",


### PR DESCRIPTION
Trello card [#1895](https://trello.com/c/DHIPBj0T/1895-fix-tests-completed-case-metrics).