### PR TITLE
1904: Remove (nested) redundant check if user is logged in

### DIFF
--- a/accessibility_monitoring_platform/templates/footer.html
+++ b/accessibility_monitoring_platform/templates/footer.html
@@ -20,15 +20,13 @@
                     <a class="govuk-footer__link" href="{% url 'common:contact-admin' %}">Contact admin</a>
                   {% endif %}
                 </li>
-                {% if user.is_authenticated %}
-                  <li class="govuk-footer__inline-list-item">
-                    {% if django_settings.AMP_PROTOTYPE_NAME and django_settings.AMP_PROTOTYPE_NAME != 'TEST' %}
-                      Report an issue
-                    {% else %}
-                      <a class="govuk-footer__link" href="{% url 'common:issue-report' %}?page_url={{ request.path }}&page_title={{ sitemap.current_platform_page.get_name }}" target="_blank">Report an issue</a>
-                    {% endif %}
-                  </li>
-                {% endif %}
+                <li class="govuk-footer__inline-list-item">
+                  {% if django_settings.AMP_PROTOTYPE_NAME and django_settings.AMP_PROTOTYPE_NAME != 'TEST' %}
+                    Report an issue
+                  {% else %}
+                    <a class="govuk-footer__link" href="{% url 'common:issue-report' %}?page_url={{ request.path }}&page_title={{ sitemap.current_platform_page.get_name }}" target="_blank">Report an issue</a>
+                  {% endif %}
+                </li>
                 {% for custom_footer_link in custom_footer_links %}
                   <li class="govuk-footer__inline-list-item">
                     <a class="govuk-footer__link" href="{{ custom_footer_link.url }}" target="_blank">


### PR DESCRIPTION
Trello card [#1904](https://trello.com/c/Wt7qBhXO/1904-add-external-links-to-the-footer).