### PR TITLE
1880: Mask auth-password content in django-axes records

### DIFF
--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -258,6 +258,7 @@ MARKDOWN_EXTENSIONS = ["fenced_code", "sane_lists"]
 # django-axes
 AXES_LOCKOUT_PARAMETERS = ["username"]  # Block only on username
 AXES_FAILURE_LIMIT = 20
+AXES_PASSWORD_FORM_FIELD = "auth-password"
 
 if UNDER_TEST:
     #  django-axes is incompatible with the platform test environment


### PR DESCRIPTION
Trello card [#1880](https://trello.com/c/gwpOkmI1/1880-axe-login-manager-is-recording-the-post-attempt-in-plain-text).