### PR TITLE
1880: Delete django-axes access attempts and logs over 7 days old

### DIFF
--- a/accessibility_monitoring_platform/settings/base.py
+++ b/accessibility_monitoring_platform/settings/base.py
@@ -259,6 +259,7 @@ MARKDOWN_EXTENSIONS = ["fenced_code", "sane_lists"]
 AXES_LOCKOUT_PARAMETERS = ["username"]  # Block only on username
 AXES_FAILURE_LIMIT = 20
 AXES_PASSWORD_FORM_FIELD = "auth-password"
+AXES_COOLOFF_TIME = 7 * 24  # Number of hours in one week
 
 if UNDER_TEST:
     #  django-axes is incompatible with the platform test environment

--- a/amp_platform.DockerFile
+++ b/amp_platform.DockerFile
@@ -19,4 +19,5 @@ CMD make static_files_process \
     && python manage.py migrate \
     && python manage.py recache_statuses \
     && python manage.py clearsessions \
+    && python manage.py axes_reset_logs --age 7 \
     && waitress-serve --port=8001 --threads=5 accessibility_monitoring_platform.wsgi:application


### PR DESCRIPTION
Trello card [#1880](https://trello.com/c/gwpOkmI1/1880-axe-login-manager-is-recording-the-post-attempt-in-plain-text).