### PR TITLE
1912: User smaller font (16px) in email templates

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/template_preview.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/template_preview.html
@@ -30,7 +30,7 @@
 {% block subcontent %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <div id="email-text" class="amp-report-wrapper">
+            <div id="email-text" class="amp-email-template">
                 {{ email_template_render }}
             </div>
         </div>

--- a/accessibility_monitoring_platform/apps/common/templates/common/emails/template_preview.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/emails/template_preview.html
@@ -52,7 +52,7 @@
         </div>
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <div id="email-text" class="amp-report-wrapper">
+                <div id="email-text" class="amp-email-template">
                     {{ email_template_render }}
                 </div>
             </div>

--- a/common/static/scss/_global.scss
+++ b/common/static/scss/_global.scss
@@ -599,6 +599,12 @@ img, .amp-max-width-100 {
     }
 }
 
+.amp-email-template {
+    @extend .amp-report-wrapper;
+    font-size: 1rem;
+    line-height: 1.25;
+}
+
 .amp-no-bullet-points {
     ul {
         padding: 0;


### PR DESCRIPTION
Trello card [#1912](https://trello.com/c/ipRxdtgq/1912-make-font-smaller-in-email-templates).