### PR TITLE
1938: Statement custom issues created in initial test should have state 'No'.

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/views/initial.py
+++ b/accessibility_monitoring_platform/apps/audits/views/initial.py
@@ -512,6 +512,8 @@ class CustomIssueCreateView(CreateView):
         audit: Audit = get_object_or_404(Audit, id=self.kwargs.get("audit_id"))
         statement_check_result: StatementCheckResult = form.save(commit=False)
         statement_check_result.audit = audit
+        if statement_check_result.type == StatementCheck.Type.CUSTOM:
+            statement_check_result.check_result_state = StatementCheckResult.Result.NO
         return super().form_valid(form)
 
     def get_success_url(self) -> str:


### PR DESCRIPTION
Trello card [#1938](https://trello.com/c/dv2Ls2B1/1938-custom-issues-not-included-in-report).