### PR TITLE
1955: Reformat issue identifiers in email templates

### DIFF
--- a/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/4-12-week-update-request.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/4-12-week-update-request.html
@@ -100,6 +100,8 @@ You do not need to provide information from your own audit.
             {% for statement_check_result in case.audit.failed_statement_check_results %}
                 <tr valign="top">
                     <td headers="statement-issue" width=50%>
+                        <b>Issue {{ statement_check_result.issue_identifier }}</b>
+                        <br>
                         {{ statement_check_result.statement_check.report_text }}
                         {% if statement_check_result.report_comment %}
                             {% if statement_check_result.statement_check.report_text %}
@@ -108,8 +110,6 @@ You do not need to provide information from your own audit.
                             {% endif %}
                             {{ statement_check_result.report_comment }}
                         {% endif %}
-                        <br>
-                        [{{ statement_check_result.issue_identifier }}]
                     </td>
                     <td headers="statement-12-week-update" width=50%></td>
                 </tr>

--- a/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/5a-outstanding-issues-initial-test-notes.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/5a-outstanding-issues-initial-test-notes.html
@@ -25,8 +25,8 @@ Please review the issues listed below and provide an update.
     {% for check_result in page.unfixed_check_results %}
     <tr valign="top">
     <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>
+        <p><b>Issue {{ check_result.issue_identifier }}</b></p>
         <p><a href="{{ check_result.wcag_definition.url_on_w3 }}">{{ check_result.wcag_definition.name }}</a></p>
-        <p>[{{ check_result.issue_identifier }}]</p>
     </td>
     <td headers="where-found-{{ forloop.parentloop.counter }}" width=33%>{{ check_result.notes|markdown_to_html }}</td>
     <td headers="12-week-update-{{ forloop.parentloop.counter }}" width=33%></td>
@@ -55,9 +55,9 @@ Please review the issues listed below and provide an update.
 {% for statement_check_result in case.audit.outstanding_statement_check_results %}
 <tr valign="top">
 <td headers="statement-issue" width=50%>
+<p><b>Issue {{ statement_check_result.issue_identifier }}</b></p>
 <p>{{ statement_check_result.statement_check.report_text }}</p>
 {{ statement_check_result.report_comment|markdown_to_html }}
-<p>[{{ statement_check_result.issue_identifier }}]</p>
 </td>
 <td headers="statement-12-week-update" width=50%>
 {{ statement_check_result.retest_comment|markdown_to_html }}

--- a/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/5b-outstanding-issues-12-week-retest-notes.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/5b-outstanding-issues-12-week-retest-notes.html
@@ -29,9 +29,9 @@ Please review the issues listed below and provide an update.
                         {% for check_result in page.unfixed_check_results %}
                             <tr valign="top">
                                 <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>
+                                    <p><b>Issue {{ check_result.issue_identifier }}</b></p>
                                     <p><a href="{{ check_result.wcag_definition.url_on_w3 }}">{{ check_result.wcag_definition.name }}</a></p>
                                     {{ check_result.notes|markdown_to_html }}
-                                    <p>[{{ check_result.issue_identifier }}]</p>
                                 </td>
                                 <td headers="retest-notes-{{ forloop.parentloop.counter }}" width=33%>{{ check_result.retest_notes|markdown_to_html }}</td>
                                 <td headers="12-week-update-{{ forloop.parentloop.counter }}" width=33%></td>
@@ -68,8 +68,8 @@ Please review the issues listed below and provide an update.
             {% for statement_check_result in case.audit.outstanding_statement_check_results %}
                 <tr valign="top">
                     <td headers="statement-issue" width=33%>
+                        <p><b>Issue {{ statement_check_result.issue_identifier }}</b></p>
                         <p>{{ statement_check_result.statement_check.report_text }}</p>
-                        <p>[{{ statement_check_result.issue_identifier }}]</p>
                     </td>
                     <td headers="statement-issue" width=33%>
                         {{ statement_check_result.report_comment|markdown_to_html }}

--- a/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/5c-outstanding-issues-12-week-retest-notes-statement-only.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/5c-outstanding-issues-12-week-retest-notes-statement-only.html
@@ -20,8 +20,8 @@ Please review the issues listed below and provide an update.
             {% for statement_check_result in case.audit.outstanding_statement_check_results %}
                 <tr valign="top">
                     <td headers="statement-issue" width=33%>
+                        <p><b>Issue {{ statement_check_result.issue_identifier }}</b></p>
                         <p>{{ statement_check_result.statement_check.report_text }}</p>
-                        <p>[{{ statement_check_result.issue_identifier }}]</p>
                     </td>
                     <td headers="statement-issue" width=33%>
                         {{ statement_check_result.report_comment|markdown_to_html }}

--- a/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/7a-equality-body-retest-all-issues.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/7a-equality-body-retest-all-issues.html
@@ -119,15 +119,15 @@ Most recent retest: {{ case.retests.first.date_of_retest|amp_date }}
     {% for retest_check_result in retest_page.original_check_results %}
     <tr valign="top">
     <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>
+    <b>Issue {{ retest_check_result.issue_identifier }}</b>
+    <br>
+    <br>
     {% if retest_check_result.check_result.wcag_definition.url_on_w3 %}
     <a href="{{ retest_check_result.check_result.wcag_definition.url_on_w3 }}">
     {{ retest_check_result.check_result.wcag_definition.name }}</a>
     {% else %}
     {{ retest_check_result.check_result.wcag_definition.name }}
     {% endif %}
-    <br>
-    <br>
-    [{{ retest_check_result.issue_identifier }}]
     <br>
     <br>
     {{ retest_check_result.check_result.wcag_definition.description|markdown_to_html }}
@@ -192,12 +192,13 @@ Disproportionate burden was: {{ retest.get_disproportionate_burden_claim_display
     {% for failed_statement_check_result in retest.failed_statement_check_results %}
     <tr valign="top">
     <td headers="statement-issue-{{ forloop.parentloop.counter }}" width=100%>
+    <b>Issue {{ failed_statement_check_result.issue_identifier }}</b>
+    <br>
     {{ failed_statement_check_result.statement_check.report_text }}
     {% if failed_statement_check_result.comment %}
     <br>
     <br>
     {{ failed_statement_check_result.comment|markdown_to_html }}
-    [{{ failed_statement_check_result.issue_identifier }}]
     {% endif %}
     </td>
     </tr>

--- a/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/7b-equality-body-retest-unfixed-issues.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/emails/templates/7b-equality-body-retest-unfixed-issues.html
@@ -126,15 +126,15 @@ Most recent retest: {{ case.retests.first.date_of_retest|amp_date }}
                     {% for retest_check_result in retest_page.unfixed_check_results %}
                         <tr valign="top">
                             <td headers="issue-{{ forloop.parentloop.counter }}" width=33%>
+                                <b>Issue {{ retest_check_result.issue_identifier }}</b>
+                                <br>
+                                <br>
                                 {% if retest_check_result.check_result.wcag_definition.url_on_w3 %}
                                     <a href="{{ retest_check_result.check_result.wcag_definition.url_on_w3 }}">
                                     {{ retest_check_result.check_result.wcag_definition.name }}</a>
                                 {% else %}
                                     {{ retest_check_result.check_result.wcag_definition.name }}
                                 {% endif %}
-                                <br>
-                                <br>
-                                [{{ retest_check_result.issue_identifier }}]
                                 <br>
                                 <br>
                                 {{ retest_check_result.check_result.wcag_definition.description|markdown_to_html }}
@@ -200,13 +200,14 @@ Disproportionate burden was: {{ retest.get_disproportionate_burden_claim_display
         {% for failed_statement_check_result in retest.failed_statement_check_results %}
             <tr valign="top">
                 <td headers="statement-issue-{{ forloop.parentloop.counter }}" width=100%>
+                    <b>Issue {{ failed_statement_check_result.issue_identifier }}</b>
+                    <br>
                     {{ failed_statement_check_result.statement_check.report_text }}
                     {% if failed_statement_check_result.comment %}
                         <br>
                         <br>
                         {{ failed_statement_check_result.comment|markdown_to_html }}
                     {% endif %}
-                    [{{ failed_statement_check_result.issue_identifier }}]
                 </td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
Trello card [#1955](https://trello.com/c/CPmTB45L/1955-reformat-issue-identifiers-in-email-templates).