### PR TITLE
1959: Restore Return to previous page widget to email template preview pages

### DIFF
--- a/accessibility_monitoring_platform/apps/cases/templates/cases/emails/template_preview.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/emails/template_preview.html
@@ -22,6 +22,7 @@
             <button class="copy-email-to-clipboard govuk-button govuk-button--secondary">
                 Copy email template
             </button>
+            {% include "common/amp_control_go_back.html" %}
         </div>
     </div>
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/cases/views.py
+++ b/accessibility_monitoring_platform/apps/cases/views.py
@@ -1185,7 +1185,9 @@ class CaseEmailTemplateListView(
         return EmailTemplate.objects.filter(is_deleted=False)
 
 
-class CaseEmailTemplatePreviewDetailView(HideCaseNavigationMixin, DetailView):
+class CaseEmailTemplatePreviewDetailView(
+    HideCaseNavigationMixin, ShowGoBackJSWidgetMixin, DetailView
+):
     """
     View email template populated with case data
     """

--- a/accessibility_monitoring_platform/apps/common/templates/common/case_form.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/case_form.html
@@ -33,15 +33,15 @@
                 {% include "cases/helpers/edit_header.html" %}
                 {% endblock %}
                 {% block controls %}
-                {% if amp_show_go_back %}
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-full">
-                            <p class="govuk-body-m">
-                                {% include "common/amp_control_go_back.html" %}
-                            </p>
+                    {% if amp_show_go_back %}
+                        <div class="govuk-grid-row">
+                            <div class="govuk-grid-column-full">
+                                <p class="govuk-body-m">
+                                    {% include "common/amp_control_go_back.html" %}
+                                </p>
+                            </div>
                         </div>
-                    </div>
-                {% endif %}
+                    {% endif %}
                 {% endblock %}
                 {% include 'common/error_summary.html' %}
                 {% block preform %}{% endblock %}


### PR DESCRIPTION
Trello card [#1959](https://trello.com/c/9xnLqkTQ/1959-re-add-return-to-previous-page-link-to-individual-email-templates).