### PR TITLE
1995: Start overnight deploys to production an hour earlier

### DIFF
--- a/.github/workflows/deploy-to-prod.yml
+++ b/.github/workflows/deploy-to-prod.yml
@@ -3,7 +3,7 @@ name: Deploy to production
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: '0 4 * * *' # runs daily at 00:00
+    - cron: '0 3 * * *' # runs daily at 00:00
 
 jobs:
   test:


### PR DESCRIPTION
Trello card [#1995](https://trello.com/c/XSop5oXn/1995-run-overnight-deploy-to-production-earlier).