### PR TITLE
1848: Remove conditional warning and condition

### DIFF
--- a/accessibility_monitoring_platform/apps/simplified/templates/simplified/forms/report_four_week_followup.html
+++ b/accessibility_monitoring_platform/apps/simplified/templates/simplified/forms/report_four_week_followup.html
@@ -9,12 +9,8 @@
 
 {% block formfields %}
 {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-{% if case.report_acknowledged_date %}
-    {% include 'simplified/helpers/report_acknowledged_warning.html' %}
-{% else %}
-    {% include 'simplified/helpers/amp_due_date_field.html' with field=form.report_followup_week_4_sent_date due_date=case.report_followup_week_4_due_date due_date_field=form.report_followup_week_4_due_date %}
-    {% include 'simplified/helpers/amp_email_field.html' with field=form.four_week_followup_sent_to_email %}
-{% endif %}
+{% include 'simplified/helpers/amp_due_date_field.html' with field=form.report_followup_week_4_sent_date due_date=case.report_followup_week_4_due_date due_date_field=form.report_followup_week_4_due_date %}
+{% include 'simplified/helpers/amp_email_field.html' with field=form.four_week_followup_sent_to_email %}
 {% include 'common/amp_field.html' with field=form.correspondence_notes %}
 {% include 'common/amp_field.html' with field=form.four_week_followup_complete_date %}
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/simplified/templates/simplified/forms/report_one_week_followup.html
+++ b/accessibility_monitoring_platform/apps/simplified/templates/simplified/forms/report_one_week_followup.html
@@ -9,12 +9,8 @@
 
 {% block formfields %}
 {% include 'common/form_hidden_fields.html' with hidden_fields=form.hidden_fields %}
-{% if case.report_acknowledged_date %}
-    {% include 'simplified/helpers/report_acknowledged_warning.html' %}
-{% else %}
-    {% include 'simplified/helpers/amp_due_date_field.html' with field=form.report_followup_week_1_sent_date due_date=case.report_followup_week_1_due_date due_date_field=form.report_followup_week_1_due_date %}
-    {% include 'simplified/helpers/amp_email_field.html' with field=form.one_week_followup_sent_to_email %}
-{% endif %}
+{% include 'simplified/helpers/amp_due_date_field.html' with field=form.report_followup_week_1_sent_date due_date=case.report_followup_week_1_due_date due_date_field=form.report_followup_week_1_due_date %}
+{% include 'simplified/helpers/amp_email_field.html' with field=form.one_week_followup_sent_to_email %}
 {% include 'common/amp_field.html' with field=form.correspondence_notes %}
 {% include 'common/amp_field.html' with field=form.one_week_followup_complete_date %}
 {% endblock %}

--- a/accessibility_monitoring_platform/apps/simplified/templates/simplified/helpers/report_acknowledged_warning.html
+++ b/accessibility_monitoring_platform/apps/simplified/templates/simplified/helpers/report_acknowledged_warning.html
@@ -1,7 +1,0 @@
-<div class="govuk-warning-text">
-    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
-    <strong class="govuk-warning-text__text">
-        <span class="govuk-warning-text__assistive">Warning</span>
-        The report has been acknowledged by the organisation, and no further follow-up is needed.
-    </strong>
-</div>

--- a/accessibility_monitoring_platform/apps/simplified/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/simplified/tests/test_views.py
@@ -164,9 +164,6 @@ UNRESOLVED_EQUALITY_BODY_MESSAGE: str = (
 UNRESOLVED_EQUALITY_BODY_NOTES: str = "Unresolved equality body correspondence notes"
 STATEMENT_CHECK_RESULT_REPORT_COMMENT: str = "Statement check result report comment"
 STATEMENT_CHECK_RESULT_RETEST_COMMENT: str = "Statement check result retest comment"
-REPORT_ACKNOWLEDGED_WARNING: str = (
-    "The report has been acknowledged by the organisation, and no further follow-up is needed."
-)
 TWELVE_WEEK_CORES_ACKNOWLEDGED_WARNING: str = (
     "The request for a final update has been acknowledged by the organisation"
 )
@@ -1710,39 +1707,6 @@ def test_case_report_one_week_followup_contains_followup_due_date(admin_client):
     )
 
 
-def test_case_report_one_week_followup_shows_warning_if_report_ack(admin_client):
-    """
-    Test that the case report one week followup view shows a warning if the report
-    has been acknowledged
-    """
-    simplified_case: SimplifiedCase = SimplifiedCase.objects.create()
-
-    response: HttpResponse = admin_client.get(
-        reverse(
-            "simplified:edit-report-one-week-followup",
-            kwargs={"pk": simplified_case.id},
-        )
-    )
-
-    assert response.status_code == 200
-
-    assertNotContains(response, REPORT_ACKNOWLEDGED_WARNING)
-
-    simplified_case.report_acknowledged_date = TODAY
-    simplified_case.save()
-
-    response: HttpResponse = admin_client.get(
-        reverse(
-            "simplified:edit-report-one-week-followup",
-            kwargs={"pk": simplified_case.id},
-        )
-    )
-
-    assert response.status_code == 200
-
-    assertContains(response, REPORT_ACKNOWLEDGED_WARNING)
-
-
 def test_case_report_four_week_followup_contains_followup_due_date(admin_client):
     """Test that the case report four week followup view contains the followup due date"""
     simplified_case: SimplifiedCase = SimplifiedCase.objects.create(
@@ -1762,39 +1726,6 @@ def test_case_report_four_week_followup_contains_followup_due_date(admin_client)
         response,
         f"Due {amp_format_date(FOUR_WEEK_FOLLOWUP_DUE_DATE)}",
     )
-
-
-def test_case_report_four_week_followup_shows_warning_if_report_ack(admin_client):
-    """
-    Test that the case report four week followup view shows a warning if the report
-    has been acknowledged
-    """
-    simplified_case: SimplifiedCase = SimplifiedCase.objects.create()
-
-    response: HttpResponse = admin_client.get(
-        reverse(
-            "simplified:edit-report-four-week-followup",
-            kwargs={"pk": simplified_case.id},
-        )
-    )
-
-    assert response.status_code == 200
-
-    assertNotContains(response, REPORT_ACKNOWLEDGED_WARNING)
-
-    simplified_case.report_acknowledged_date = TODAY
-    simplified_case.save()
-
-    response: HttpResponse = admin_client.get(
-        reverse(
-            "simplified:edit-report-four-week-followup",
-            kwargs={"pk": simplified_case.id},
-        )
-    )
-
-    assert response.status_code == 200
-
-    assertContains(response, REPORT_ACKNOWLEDGED_WARNING)
 
 
 def test_case_report_twelve_week_1_week_chaser_contains_followup_due_date(admin_client):


### PR DESCRIPTION
Trello card [#1848](https://trello.com/c/NVxOGukF/1848-remove-the-warning-from-the-correspondence-process-and-ensure-the-forms-are-always-visible).