### PR TITLE
2004: Restore intro paragraph before table of statement issues in report

### DIFF
--- a/common/templates/reports_common/accessibility_report_v1_8_0__20250424.html
+++ b/common/templates/reports_common/accessibility_report_v1_8_0__20250424.html
@@ -176,6 +176,9 @@
 </p>
 <p>
 {% if audit.failed_statement_check_results %}
+    <p>
+        We found the following issues:
+    </p>
     <table id="statement-check-results">
         <caption class="govuk-visually-hidden">Issues found on accessibility statement</caption>
         <thead>


### PR DESCRIPTION
Trello card [#2004](https://trello.com/c/z0MYKFNg/2004-restore-text-to-report).