### PR TITLE
v0.7.10 - Restore intro paragraph before table of statement issues in report

### DIFF
--- a/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/13_reports_in_qa.html
+++ b/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/13_reports_in_qa.html
@@ -4,7 +4,7 @@
     <table class="govuk-table">
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">
-                <th scope="col" class="govuk-table__header amp-width-15-percent">Date created</th>
+                <th scope="col" class="govuk-table__header amp-width-15-percent">Date of test</th>
                 <th scope="col" class="govuk-table__header amp-width-one-quarter">Case</th>
                 <th scope="col" class="govuk-table__header amp-width-one-quarter">QA status</th>
                 <th scope="col" class="govuk-table__header amp-width-one-quarter">Auditor</th>
@@ -14,7 +14,7 @@
             {% for case in all_cases_in_qa %}
                 <tr class="govuk-table__row ">
                     <th scope="row" class="govuk-table__header amp-width-15-percent govuk-!-font-weight-regular">
-                        {{ case.created|amp_date_trunc }}
+                        {% if case.audit %}{{ case.audit.date_of_test|amp_date_trunc }}{% else %}None{% endif %}
                     </th>
                     <td class="govuk-table__cell amp-width-one-quarter">
                         <a href="{% url 'simplified:edit-qa-auditor' case.id %}" class="govuk-link">

--- a/common/templates/reports_common/accessibility_report_v1_8_0__20250424.html
+++ b/common/templates/reports_common/accessibility_report_v1_8_0__20250424.html
@@ -176,6 +176,9 @@
 </p>
 <p>
 {% if audit.failed_statement_check_results %}
+    <p>
+        We found the following issues:
+    </p>
     <table id="statement-check-results">
         <caption class="govuk-visually-hidden">Issues found on accessibility statement</caption>
         <thead>


### PR DESCRIPTION
* Restore intro paragraph before table of statement issues in report ([example](https://platform.accessibility-monitoring.service.gov.uk/reports/6754/report-preview/#report-your-accessibility-statement)) [#2004](https://trello.com/c/z0MYKFNg/2004-restore-text-to-report)