### PR TITLE
2047: Replace label-tag with p-tag to prevent hopping to page top on click

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/forms/equality_body_retest_page_checks.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/forms/equality_body_retest_page_checks.html
@@ -106,10 +106,10 @@
                             <div class="govuk-grid-row">
                                 <div class="govuk-grid-column-full">
                                     <hr class="amp-width-100 amp-margin-bottom-15">
-                                    <label class="govuk-label amp-margin-bottom-15">
+                                    <p class="govuk-label amp-margin-bottom-15">
                                         <b>{{ form.instance.check_result.wcag_definition }}</b>
                                         {% include 'audits/helpers/issue_identifier.html' with issue=form.instance %}
-                                    </label>
+                                    </p>
                                     <details class="govuk-details amp-margin-bottom-10" data-module="govuk-details">
                                         <summary class="govuk-details__summary">
                                             <span class="govuk-details__summary-text">Previous test notes</span>


### PR DESCRIPTION
Trello card [#2047](https://trello.com/c/tRwI4o46/2047-label-tag-with-no-field-goes-to-page-top).