### PR TITLE
2037: Remove password from 'Account details' page

### DIFF
--- a/accessibility_monitoring_platform/apps/users/forms.py
+++ b/accessibility_monitoring_platform/apps/users/forms.py
@@ -105,9 +105,6 @@ class UserUpdateForm(forms.ModelForm):
     )
     first_name = AMPCharFieldWide(required=True, max_length=150)
     last_name = AMPCharFieldWide(required=True, max_length=150)
-    password = AMPPasswordField(
-        help_text="Enter your password to confirm the update",
-    )
 
     class Meta:
         model = User
@@ -116,16 +113,8 @@ class UserUpdateForm(forms.ModelForm):
             "enable_2fa",
             "first_name",
             "last_name",
-            "password",
         ]
 
     def __init__(self, user, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.user = user
-
-    def clean_password(self):
-        cleaned_data: Any = super().clean()
-        password: Any = cleaned_data.get("password")
-        if self.user.check_password(password) is False:
-            raise forms.ValidationError("Password is incorrect")
-        return password

--- a/accessibility_monitoring_platform/apps/users/tests/test_forms.py
+++ b/accessibility_monitoring_platform/apps/users/tests/test_forms.py
@@ -118,15 +118,3 @@ def test_valid_user_update_form():
     )
 
     assert form.is_valid()
-
-
-@pytest.mark.django_db
-def test_incorrect_password_returns_error():
-    """Returns an error if password is incorrect"""
-    user: User = create_user()
-    data: UserUpdateFormData = VALID_USER_UPDATE_FORM_DATA.copy()
-    data["password"] = INVALID_PASSWORD
-
-    form: UserUpdateForm = UserUpdateForm(data=data or None, user=user)
-
-    assert form.errors["password"] == ["Password is incorrect"]

--- a/accessibility_monitoring_platform/apps/users/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/users/tests/test_views.py
@@ -214,26 +214,6 @@ def test_edit_user_post_saves_correctly(client):
 
 
 @pytest.mark.django_db
-def test_edit_user_post_errors_appear(client):
-    """Tests if error message appears if there is a mistake in the form"""
-    AllowedEmail.objects.create(inclusion_email=VALID_USER_EMAIL)
-    user: User = create_user()
-    client.login(username=VALID_USER_EMAIL, password=VALID_PASSWORD)
-
-    data: UserUpdateFormData = VALID_USER_UPDATE_FORM_DATA.copy()
-    data["password"] = INVALID_PASSWORD
-
-    response: HttpResponse = client.post(
-        reverse("users:edit-user", kwargs={"pk": user.id}),
-        data=data,
-        follow=True,
-    )
-
-    assert response.status_code == 200
-    assertContains(response, "Password is incorrect")
-
-
-@pytest.mark.django_db
 def test_2fa_not_enabled_on_user_creation(client):
     """Tests to see if 2FA EmailDevice not created when user is registered"""
     AllowedEmail.objects.create(inclusion_email=VALID_USER_EMAIL)


### PR DESCRIPTION
Trello card [#2037](https://trello.com/c/ozdtLvXv/2037-remove-password-requirement-from-settings-page).