### PR TITLE
2055: Correct spelling of 'confirm'

### DIFF
--- a/accessibility_monitoring_platform/apps/simplified/forms.py
+++ b/accessibility_monitoring_platform/apps/simplified/forms.py
@@ -977,7 +977,7 @@ class ZendeskTicketConfirmDeleteUpdateForm(forms.ModelForm):
     """
 
     is_deleted = forms.BooleanField(
-        label="Conform you want to remove Zendest ticket",
+        label="Confirm you want to remove Zendest ticket",
         required=False,
         widget=AMPBooleanCheckboxWidget(attrs={"label": "Remove ticket"}),
     )


### PR DESCRIPTION
Trello card [#2055](https://trello.com/c/9GZZQlRU/2055-amend-spelling-mistake-conform-you-want-to-remove-zendest-ticket).