### PR TITLE
2062: Add link to edit Active QA auditor on homepage

### DIFF
--- a/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/overview.html
+++ b/accessibility_monitoring_platform/apps/dashboard/templates/dashboard/overview.html
@@ -6,6 +6,7 @@
         {% else %}
             None
         {% endif%}
+        (<a href="{% url 'common:edit-active-qa-auditor' %}" class="govuk-link govuk-link--no-visited-state">Edit</a>)
     </p>
 </div>
 <div class="amp-margin-bottom-25">


### PR DESCRIPTION
Trello card [#2062](https://trello.com/c/rKSRVy5i/2062-add-edit-link-to-qa-auditor-in-dashboard).