### PR TITLE
2078: Fix link in QA comment notification email

### DIFF
--- a/accessibility_monitoring_platform/apps/notifications/tests/test_utils.py
+++ b/accessibility_monitoring_platform/apps/notifications/tests/test_utils.py
@@ -94,6 +94,62 @@ def test_mark_tasks_as_read_marks_task_as_read(rf):
 
 
 @pytest.mark.django_db
+def test_add_task_qa_comment_correct_link_in_email_simplified(mailoutbox, rf):
+    """test to check if add_task adds task and sends email for simplified case"""
+    request: HttpRequest = rf.get("/")
+    user: User = User.objects.create_user(  # type: ignore
+        username="mockuser", email="mockuser@mock.com", password="secret"
+    )
+    request.user = user
+    NotificationSetting.objects.create(user=user)
+    base_case: BaseCase = BaseCase.objects.create(
+        test_type=BaseCase.TestType.SIMPLIFIED
+    )
+
+    add_task(
+        user=user,
+        base_case=base_case,
+        type=Task.Type.QA_COMMENT,
+        description="this is a notification",
+        email_description="There is a notification",
+        request=request,
+    )
+
+    assert len(mailoutbox) == 1
+    assert (
+        reverse("simplified:edit-qa-comments", kwargs={"pk": base_case.id})
+        in mailoutbox[0].body
+    )
+
+
+@pytest.mark.django_db
+def test_add_task_qa_comment_correct_link_in_email_detailed(mailoutbox, rf):
+    """test to check if add_task adds task and sends email for detailed case"""
+    request: HttpRequest = rf.get("/")
+    user: User = User.objects.create_user(  # type: ignore
+        username="mockuser", email="mockuser@mock.com", password="secret"
+    )
+    request.user = user
+    NotificationSetting.objects.create(user=user)
+    base_case: BaseCase = BaseCase.objects.create(test_type=BaseCase.TestType.DETAILED)
+
+    add_task(
+        user=user,
+        base_case=base_case,
+        type=Task.Type.QA_COMMENT,
+        description="this is a notification",
+        email_description="There is a notification",
+        request=request,
+    )
+
+    assert len(mailoutbox) == 1
+    assert (
+        reverse("detailed:edit-qa-comments", kwargs={"pk": base_case.id})
+        in mailoutbox[0].body
+    )
+
+
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "type",
     [Task.Type.QA_COMMENT, Task.Type.REPORT_APPROVED],

--- a/accessibility_monitoring_platform/apps/notifications/utils.py
+++ b/accessibility_monitoring_platform/apps/notifications/utils.py
@@ -68,9 +68,13 @@ def add_task(
         email_settings.save()
 
     if type == Task.Type.QA_COMMENT:
-        path: str = reverse("simplified:edit-qa-comments", kwargs={"pk": base_case.id})
+        path: str = reverse(
+            f"{base_case.test_type}:edit-qa-comments", kwargs={"pk": base_case.id}
+        )
     else:
-        path: str = reverse("simplified:edit-qa-approval", kwargs={"pk": base_case.id})
+        path: str = reverse(
+            f"{base_case.test_type}:edit-qa-approval", kwargs={"pk": base_case.id}
+        )
 
     if email_settings.email_notifications_enabled:
         context: EmailContextType = {


### PR DESCRIPTION
Trello card [#2078](https://trello.com/c/i4rqr6GI/2078-fix-link-in-qa-comment-email).