### PR TITLE
2085: Add internal links to top and bottom of summary pages

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/test_summary.html
+++ b/accessibility_monitoring_platform/apps/audits/templates/audits/helpers/test_summary.html
@@ -217,6 +217,7 @@
                     </table>
                 </div>
             </div>
+            {% include 'common/top_and_bottom.html' %}
         {% endfor %}
     {% else %}
         {% for wcag_definition, failures in audit_failures_by_wcag.items %}
@@ -284,6 +285,7 @@
                     </table>
                 </div>
             </div>
+            {% include 'common/top_and_bottom.html' %}
         {% endfor %}
         {% if pages_with_retest_notes %}
             <h2 id="additional-page-issues" class="govuk-heading-m govuk-!-font-size-19 govuk-!-font-weight-bold">Additional issues found on page ({{ pages_with_retest_notes|length }})</h2>
@@ -334,6 +336,7 @@
                 {% endfor %}
                 </tbody>
             </table>
+            {% include 'common/top_and_bottom.html' %}
         {% endif %}
     {% endif %}
 {% endif %}
@@ -345,5 +348,8 @@
         {% else %}
             {% include 'audits/helpers/test_summary_initial_statement_content.html' %}
         {% endif %}
+        {% include 'common/top_and_bottom.html' %}
     {% endfor %}
 {% endif %}
+
+<hr id="bottom-of-page" class="amp-width-100 amp-margin-bottom-30">

--- a/accessibility_monitoring_platform/apps/common/templates/common/top_and_bottom.html
+++ b/accessibility_monitoring_platform/apps/common/templates/common/top_and_bottom.html
@@ -1,0 +1,6 @@
+<div class="govuk-grid-row amp-margin-bottom-20 amp-margin-top-20">
+    <div class="govuk-grid-column-full govuk-button-group">
+        ▼ &nbsp; <a href="#bottom-of-page" class="govuk-link govuk-link--no-visited-state">Go to bottom of page</a>
+        ▲ &nbsp; {% include 'common/back_to_top.html' %}
+    </div>
+</div>


### PR DESCRIPTION
Trello card [#2085](https://trello.com/c/032hCPfi/2085-add-internal-links-to-summary-pages).