### PR TITLE
v0.7.86 - Remove brackets from case navigation

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/audits/tests/test_views.py
@@ -3653,7 +3653,7 @@ def test_nav_details_page_renders(admin_client):
         response,
         """<details class="amp-nav-details">
             <summary class="amp-nav-details__summary">
-                Case details (0/1)
+                Case details 0/1
             </summary>
             <div class="amp-nav-details__text">
                 <ul class="govuk-list amp-margin-bottom-5">
@@ -3669,7 +3669,7 @@ def test_nav_details_page_renders(admin_client):
     assertContains(
         response,
         """<p class="govuk-body-s amp-margin-bottom-5">
-            Initial WCAG test (0/5)
+            Initial WCAG test 0/5
         </p>""",
         html=True,
     )
@@ -3708,7 +3708,7 @@ def test_nav_details_subpage_renders(admin_client):
         response,
         """<details class="amp-nav-details">
             <summary class="amp-nav-details__summary">
-                Case details (0/1)
+                Case details 0/1
             </summary>
             <div class="amp-nav-details__text">
                 <ul class="govuk-list amp-margin-bottom-5">
@@ -3724,7 +3724,7 @@ def test_nav_details_subpage_renders(admin_client):
     assertContains(
         response,
         """<p class="govuk-body-s amp-margin-bottom-5">
-            Initial WCAG test (0/5)
+            Initial WCAG test 0/5
         </p>""",
         html=True,
     )

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/details/details_case_files.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/details/details_case_files.html
@@ -1,0 +1,36 @@
+<h3 class="govuk-heading-s">
+    {% if case_detail_page.page.platform_page_group.name %}
+        {{ case_detail_page.page.platform_page_group.name }} |
+    {% endif %}
+    <a href="{{ case_detail_page.page.url }}" class="govuk-link govuk-link--no-visited-state">{{ case_detail_page.page.get_name }}</a>
+</h3>
+{% if case.case_files %}
+    <table class="govuk-table amp-file-management-table govuk-!-font-size-16" data-search-target-page-name="{{ case_detail_page.page.platform_page_group.name }}" data-search-target-label="{{ case_detail_page.page.get_name }}" data-search-target-url="{{ case_detail_page.page.url }}">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Filename</th>
+                <th scope="col" class="govuk-table__header">Uploaded</th>
+                <th scope="col" class="govuk-table__header">Type</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            {% for case_file in case.case_files %}
+                <tr class="govuk-table__row">
+                    <td scope="row" class="govuk-table__cell">
+                        <a href="{% url 'cases:case-file-download' case_file.id %}" class="govuk-link govuk-link--no-visited-state" target="_blank">
+                            {{ case_file.name }}
+                        </a>
+                    </td>
+                    <td scope="row" class="govuk-table__cell amp-case-date">
+                        {{ case_file.uploaded_time|amp_date_trunc }}
+                    </td>
+                    <td scope="row" class="govuk-table__cell amp-file-type">
+                        {{ case_file.get_type_display }}
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% else %}
+    <p class="govuk-body-m">No files uploaded</p>
+{% endif %}

--- a/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/case_nav.html
+++ b/accessibility_monitoring_platform/apps/cases/templates/cases/helpers/case_nav.html
@@ -4,7 +4,7 @@
             <p class="govuk-body-s amp-margin-bottom-5">
                 {{ platform_page_group.name }}
                 {% if platform_page_group.number_pages_and_subpages > 0 %}
-                    ({{ platform_page_group.number_complete }}/{{ platform_page_group.number_pages_and_subpages }})
+                    {{ platform_page_group.number_complete }}/{{ platform_page_group.number_pages_and_subpages }}
                 {% endif %}
             </p>
             {% include 'cases/helpers/case_nav_group_pages.html' with section_selected=True %}
@@ -13,7 +13,7 @@
                 <summary class="amp-nav-details__summary">
                     {{ platform_page_group.name }}
                     {% if platform_page_group.number_pages_and_subpages > 0 %}
-                        ({{ platform_page_group.number_complete }}/{{ platform_page_group.number_pages_and_subpages }})
+                        {{ platform_page_group.number_complete }}/{{ platform_page_group.number_pages_and_subpages }}
                     {% endif %}
                 </summary>
                 {% include 'cases/helpers/case_nav_group_pages.html' %}

--- a/accessibility_monitoring_platform/apps/common/sitemap.py
+++ b/accessibility_monitoring_platform/apps/common/sitemap.py
@@ -1540,6 +1540,7 @@ SIMPLIFIED_CASE_PAGE_GROUPS: list[PlatformPageGroup] = [
             BaseCasePlatformPage(
                 name="Case files manager",
                 url_name="simplified:case-file-list",
+                case_details_template_name="cases/details/details_case_files.html",
             ),
             SimplifiedCasePlatformPage(
                 name="Outstanding issues",
@@ -1858,6 +1859,7 @@ DETAILED_CASE_PAGE_GROUPS: list[PlatformPageGroup] = [
             BaseCasePlatformPage(
                 name="Case files manager",
                 url_name="detailed:case-file-list",
+                case_details_template_name="cases/details/details_case_files.html",
             ),
             DetailedCasePlatformPage(
                 name="Email templates",
@@ -2208,6 +2210,7 @@ MOBILE_CASE_PAGE_GROUPS: list[PlatformPageGroup] = [
             BaseCasePlatformPage(
                 name="Case files manager",
                 url_name="mobile:case-file-list",
+                case_details_template_name="cases/details/details_case_files.html",
             ),
             MobileCasePlatformPage(
                 name="Email templates",

--- a/accessibility_monitoring_platform/apps/common/tests/test_case_nav.py
+++ b/accessibility_monitoring_platform/apps/common/tests/test_case_nav.py
@@ -78,7 +78,7 @@ def test_current_page_in_case_nav(url_app, case_model, admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Case details (0/1)"),
+        CURRENT_PAGE_GROUP.format(name="Case details 0/1"),
         html=True,
     )
     assertContains(
@@ -127,12 +127,12 @@ def test_start_initial_test_page_shown(admin_client):
     )
     assertNotContains(
         response,
-        OTHER_PAGE_GROUP.format(name="Initial WCAG test (0/4)"),
+        OTHER_PAGE_GROUP.format(name="Initial WCAG test 0/4"),
         html=True,
     )
     assertNotContains(
         response,
-        OTHER_PAGE_GROUP.format(name="Initial statement (0/7)"),
+        OTHER_PAGE_GROUP.format(name="Initial statement 0/7"),
         html=True,
     )
 
@@ -155,12 +155,12 @@ def test_start_initial_test_page_hidden(admin_client):
     )
     assertContains(
         response,
-        OTHER_PAGE_GROUP.format(name="Initial WCAG test (0/4)"),
+        OTHER_PAGE_GROUP.format(name="Initial WCAG test 0/4"),
         html=True,
     )
     assertContains(
         response,
-        OTHER_PAGE_GROUP.format(name="Initial statement (0/7)"),
+        OTHER_PAGE_GROUP.format(name="Initial statement 0/7"),
         html=True,
     )
 
@@ -178,7 +178,7 @@ def test_dynamic_wcag_pages_hidden(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Initial WCAG test (0/4)"),
+        CURRENT_PAGE_GROUP.format(name="Initial WCAG test 0/4"),
         html=True,
     )
     assertContains(
@@ -204,7 +204,7 @@ def test_dynamic_wcag_pages_shown(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Initial WCAG test (0/5)"),
+        CURRENT_PAGE_GROUP.format(name="Initial WCAG test 0/5"),
         html=True,
     )
     assertContains(
@@ -231,7 +231,7 @@ def test_dynamic_statement_pages_hidden(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Initial statement (0/7)"),
+        CURRENT_PAGE_GROUP.format(name="Initial statement 0/7"),
         html=True,
     )
     assertContains(
@@ -263,7 +263,7 @@ def test_dynamic_statement_pages_shown(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Initial statement (0/13)"),
+        CURRENT_PAGE_GROUP.format(name="Initial statement 0/13"),
         html=True,
     )
     assertContains(response, "<b>Statement overview</b>", html=True)
@@ -293,7 +293,7 @@ def test_start_report_test_page_shown(admin_client):
     )
     assertNotContains(
         response,
-        OTHER_PAGE_GROUP.format(name="Report QA (0/4)"),
+        OTHER_PAGE_GROUP.format(name="Report QA 0/4"),
         html=True,
     )
 
@@ -316,7 +316,7 @@ def test_start_report_test_page_hidden(admin_client):
     )
     assertContains(
         response,
-        OTHER_PAGE_GROUP.format(name="Report QA (0/4)"),
+        OTHER_PAGE_GROUP.format(name="Report QA 0/4"),
         html=True,
     )
 
@@ -333,7 +333,7 @@ def test_dynamic_contact_pages_hidden(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Contact details (0/1)"),
+        CURRENT_PAGE_GROUP.format(name="Contact details 0/1"),
         html=True,
     )
     assertContains(
@@ -358,7 +358,7 @@ def test_dynamic_contact_pages_shown(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Contact details (0/1)"),
+        CURRENT_PAGE_GROUP.format(name="Contact details 0/1"),
         html=True,
     )
     assertContains(
@@ -384,7 +384,7 @@ def test_dynamic_contact_correspondence_pages_hidden(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Contact details (0/1)"),
+        CURRENT_PAGE_GROUP.format(name="Contact details 0/1"),
         html=True,
     )
     assertNotContains(
@@ -427,7 +427,7 @@ def test_dynamic_contact_correspondence_pages_shown(admin_client):
 
     assertContains(
         response,
-        CURRENT_PAGE_GROUP.format(name="Contact details (0/4)"),
+        CURRENT_PAGE_GROUP.format(name="Contact details 0/4"),
         html=True,
     )
     assertContains(
@@ -474,12 +474,12 @@ def test_start_12_week_retest_page_shown(admin_client):
     )
     assertNotContains(
         response,
-        OTHER_PAGE_GROUP.format(name="12-week WCAG test (0/4)"),
+        OTHER_PAGE_GROUP.format(name="12-week WCAG test 0/4"),
         html=True,
     )
     assertNotContains(
         response,
-        OTHER_PAGE_GROUP.format(name="12-week statement (0/6)"),
+        OTHER_PAGE_GROUP.format(name="12-week statement 0/6"),
         html=True,
     )
 
@@ -502,12 +502,12 @@ def test_start_12_week_retest_page_hidden(admin_client):
     )
     assertContains(
         response,
-        OTHER_PAGE_GROUP.format(name="12-week WCAG test (0/4)"),
+        OTHER_PAGE_GROUP.format(name="12-week WCAG test 0/4"),
         html=True,
     )
     assertContains(
         response,
-        OTHER_PAGE_GROUP.format(name="12-week statement (0/7)"),
+        OTHER_PAGE_GROUP.format(name="12-week statement 0/7"),
         html=True,
     )
 

--- a/accessibility_monitoring_platform/apps/simplified/templates/simplified/details/details_psb_zendesk_tickets.html
+++ b/accessibility_monitoring_platform/apps/simplified/templates/simplified/details/details_psb_zendesk_tickets.html
@@ -2,7 +2,7 @@
     {% if case_detail_page.page.platform_page_group.name %}
         {{ case_detail_page.page.platform_page_group.name }} |
     {% endif %}
-    <a href="{% url 'simplified:zendesk-tickets' case.id %}" class="govuk-link govuk-link--no-visited-state">PSB Zendesk tickets</a>
+    <a href="{{ case_detail_page.page.url }}" class="govuk-link govuk-link--no-visited-state">{{ case_detail_page.page.get_name }}</a>
 </h3>
 {% if case.zendesk_tickets %}
     {% for zendesk_ticket in case.zendesk_tickets %}

--- a/accessibility_monitoring_platform/apps/simplified/templates/simplified/details/details_psb_zendesk_tickets.html
+++ b/accessibility_monitoring_platform/apps/simplified/templates/simplified/details/details_psb_zendesk_tickets.html
@@ -7,7 +7,7 @@
 {% if case.zendesk_tickets %}
     {% for zendesk_ticket in case.zendesk_tickets %}
         <p class="govuk-body-m"><b>PSB Zendesk ticket #{{ zendesk_ticket.id_within_case }}</b></p>
-        <table class="govuk-table" data-search-target-page-name="" data-search-target-label="PSB Zendesk tickets" data-search-target-url="{% url 'simplified:zendesk-tickets' case.id %}">
+        <table class="govuk-table" data-search-target-page-name="{{ case_detail_page.page.platform_page_group.name }}" data-search-target-label="{{ case_detail_page.page.get_name }}" data-search-target-url="{{ case_detail_page.page.url }}">
             <tbody class="govuk-table__body">
                 <tr class="govuk-table__row">
                     <th scope="row" class="govuk-table__header amp-font-weight-normal amp-width-one-half">Summary</th>

--- a/accessibility_monitoring_platform/apps/simplified/tests/test_views.py
+++ b/accessibility_monitoring_platform/apps/simplified/tests/test_views.py
@@ -546,7 +546,7 @@ def test_case_page_with_case_nav_and_form_without_go_back(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "Case details (0/1)", html=True)
+    assertContains(response, "Case details 0/1", html=True)
     assertContains(
         response,
         f"""<form method="post" action="{url}">""",
@@ -569,7 +569,7 @@ def test_case_page_with_form_and_go_back_without_case_nav(admin_client):
 
     assert response.status_code == 200
 
-    assertNotContains(response, "Case details (0/1)", html=True)
+    assertNotContains(response, "Case details 0/1", html=True)
     assertContains(
         response,
         f"""<form method="post" action="{url}">""",
@@ -591,7 +591,7 @@ def test_case_page_with_go_back_without_form_or_case_nav(admin_client):
 
     assert response.status_code == 200
 
-    assertNotContains(response, "Case details (0/1)", html=True)
+    assertNotContains(response, "Case details 0/1", html=True)
     assertNotContains(
         response,
         f"""<form method="post" action="{url}">""",
@@ -613,7 +613,7 @@ def test_case_page_with_case_nav_no_form_and_no_go_back(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "Case details (0/1)", html=True)
+    assertContains(response, "Case details 0/1", html=True)
     assertNotContains(
         response,
         f"""<form method="post" action="{url}">""",
@@ -2020,11 +2020,11 @@ def test_case_navigation_shown_on_case_pages(case_page_url, admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "Case details (0/1)", html=True)
-    assertContains(response, "Contact details (0/4)", html=True)
-    assertContains(response, "Report correspondence (0/4)", html=True)
-    assertContains(response, "12-week correspondence (0/3)", html=True)
-    assertContains(response, "Closing the case (0/3)", html=True)
+    assertContains(response, "Case details 0/1", html=True)
+    assertContains(response, "Contact details 0/4", html=True)
+    assertContains(response, "Report correspondence 0/4", html=True)
+    assertContains(response, "12-week correspondence 0/3", html=True)
+    assertContains(response, "Closing the case 0/3", html=True)
 
 
 def test_case_navigation_shown_on_edit_equality_body_cores_page(admin_client):
@@ -2048,11 +2048,11 @@ def test_case_navigation_shown_on_edit_equality_body_cores_page(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "Case details (0/1)", html=True)
-    assertContains(response, "Contact details (0/4)", html=True)
-    assertContains(response, "Report correspondence (0/4)", html=True)
-    assertContains(response, "12-week correspondence (0/3)", html=True)
-    assertContains(response, "Closing the case (0/3)", html=True)
+    assertContains(response, "Case details 0/1", html=True)
+    assertContains(response, "Contact details 0/4", html=True)
+    assertContains(response, "Report correspondence 0/4", html=True)
+    assertContains(response, "12-week correspondence 0/3", html=True)
+    assertContains(response, "Closing the case 0/3", html=True)
 
 
 def test_case_navigation_shown_on_edit_contact_page(admin_client):
@@ -2073,11 +2073,11 @@ def test_case_navigation_shown_on_edit_contact_page(admin_client):
 
     assert response.status_code == 200
 
-    assertContains(response, "Case details (0/1)", html=True)
-    assertContains(response, "Contact details (0/4)", html=True)
-    assertContains(response, "Report correspondence (0/4)", html=True)
-    assertContains(response, "12-week correspondence (0/3)", html=True)
-    assertContains(response, "Closing the case (0/3)", html=True)
+    assertContains(response, "Case details 0/1", html=True)
+    assertContains(response, "Contact details 0/4", html=True)
+    assertContains(response, "Report correspondence 0/4", html=True)
+    assertContains(response, "12-week correspondence 0/3", html=True)
+    assertContains(response, "Closing the case 0/3", html=True)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* Remove brackets from case navigation ([example](https://platform.accessibility-monitoring.service.gov.uk/simplified/1170/edit-case-metadata/)) [#2226](https://trello.com/c/GoDwrt7r/2226-remove-brackets-in-case-navigation)
* Add case files to search all case data pages ([example](https://platform.accessibility-monitoring.service.gov.uk/detailed/2342/case-view-and-search/#page-group-9-case-tools)) [#2232](https://trello.com/c/Z4TZOP6j/2232-add-uploaded-files-to-search-in-case)