### PR TITLE
v0.7.90 - Remove deleted field from UI

### DIFF
--- a/accessibility_monitoring_platform/apps/audits/forms.py
+++ b/accessibility_monitoring_platform/apps/audits/forms.py
@@ -945,16 +945,12 @@ class AuditRetestStatementDecisionUpdateForm(VersionForm):
     Form for retesting statement decision
     """
 
-    audit_retest_accessibility_statement_backup_url = AMPURLField(
-        label="Link to 12-week saved accessibility statement, only if not compliant",
-    )
     audit_retest_statement_decision_complete_date = AMPDatePageCompleteField()
 
     class Meta:
         model = Audit
         fields: list[str] = [
             "version",
-            "audit_retest_accessibility_statement_backup_url",
             "audit_retest_statement_decision_complete_date",
         ]
 


### PR DESCRIPTION
* Remove deleted field from UI ([example](https://platform.accessibility-monitoring.service.gov.uk/audits/517/edit-audit-retest-statement-decision/)) [#2239](https://trello.com/c/efHjMPPr/2239-remove-deleted-field-from-ui)