### PR TITLE
v0.7.92 - Fix mobile QA comments link pointing at detailed URL

### DIFF
--- a/accessibility_monitoring_platform/apps/notifications/models.py
+++ b/accessibility_monitoring_platform/apps/notifications/models.py
@@ -42,11 +42,7 @@ class Task(models.Model):
     def options(self) -> list[Link]:
         options: list[Link] = []
         if self.type == Task.Type.QA_COMMENT:
-            url_name: str = (
-                "simplified:edit-qa-comments"
-                if self.base_case.test_type == TestType.SIMPLIFIED
-                else "detailed:edit-qa-comments"
-            )
+            url_name: str = f"{self.base_case.test_type}:edit-qa-comments"
             options.append(
                 Link(
                     label="Go to QA comment",
@@ -57,11 +53,7 @@ class Task(models.Model):
                 ),
             )
         elif self.type == Task.Type.REPORT_APPROVED:
-            url_name: str = (
-                "simplified:edit-qa-approval"
-                if self.base_case.test_type == TestType.SIMPLIFIED
-                else "detailed:edit-qa-approval"
-            )
+            url_name: str = f"{self.base_case.test_type}:edit-qa-approval"
             options.append(
                 Link(
                     label="Go to Report approved",

--- a/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 
 from ...common.models import Link
 from ...detailed.models import DetailedCase
+from ...mobile.models import MobileCase
 from ...simplified.models import SimplifiedCase
 from ..models import NotificationSetting, Task
 
@@ -93,6 +94,43 @@ def test_options_qa_comment_detailed():
             url=reverse(
                 "notifications:mark-case-comments-read",
                 kwargs={"case_id": detailed_case.id},
+            ),
+        ),
+    ]
+
+
+@pytest.mark.django_db
+def test_options_qa_comment_mobile():
+    """Task options for QA comment in mobile case"""
+    user: User = User.objects.create()
+    mobile_case: MobileCase = MobileCase.objects.create(auditor=user)
+    task: Task = Task.objects.create(
+        type=Task.Type.QA_COMMENT,
+        date=date.today(),
+        base_case=mobile_case,
+        user=user,
+    )
+
+    assert task.options() == [
+        Link(
+            label="Go to QA comment",
+            url=reverse(
+                "mobile:edit-qa-comments",
+                kwargs={"pk": mobile_case.id},
+            ),
+        ),
+        Link(
+            label="Mark as seen",
+            url=reverse(
+                "notifications:mark-task-read",
+                kwargs={"pk": task.id},
+            ),
+        ),
+        Link(
+            label="Mark case tasks as seen",
+            url=reverse(
+                "notifications:mark-case-comments-read",
+                kwargs={"case_id": mobile_case.id},
             ),
         ),
     ]

--- a/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
@@ -48,7 +48,7 @@ def test_task_options(
     expected_url: str,
     expected_label: str,
 ):
-    """Task options for QA comment in simplified case"""
+    """Task options for all case test types and both QA comment and Report approved"""
     user: User = User.objects.create()
     case: case_class = case_class.objects.create(auditor=user)
     task: Task = Task.objects.create(

--- a/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
@@ -26,23 +26,44 @@ def test_notifications_settings_returns_str():
 
 
 @pytest.mark.django_db
-def test_options_qa_comment_simplified():
+@pytest.mark.parametrize(
+    "case_class,case_test_type",
+    [
+        (DetailedCase, "detailed"),
+        (MobileCase, "mobile"),
+        (SimplifiedCase, "simplified"),
+    ],
+)
+@pytest.mark.parametrize(
+    "task_type,expected_url,expected_label",
+    [
+        (Task.Type.QA_COMMENT, "edit-qa-comments", "Go to QA comment"),
+        (Task.Type.REPORT_APPROVED, "edit-qa-approval", "Go to Report approved"),
+    ],
+)
+def test_task_options(
+    case_class: DetailedCase | MobileCase | SimplifiedCase,
+    case_test_type: str,
+    task_type: Task.Type,
+    expected_url: str,
+    expected_label: str,
+):
     """Task options for QA comment in simplified case"""
     user: User = User.objects.create()
-    simplified_case: SimplifiedCase = SimplifiedCase.objects.create(auditor=user)
+    case: case_class = case_class.objects.create(auditor=user)
     task: Task = Task.objects.create(
-        type=Task.Type.QA_COMMENT,
+        type=task_type,
         date=date.today(),
-        base_case=simplified_case,
+        base_case=case,
         user=user,
     )
 
     assert task.options() == [
         Link(
-            label="Go to QA comment",
+            label=expected_label,
             url=reverse(
-                "simplified:edit-qa-comments",
-                kwargs={"pk": simplified_case.id},
+                f"{case_test_type}:{expected_url}",
+                kwargs={"pk": case.id},
             ),
         ),
         Link(
@@ -56,81 +77,7 @@ def test_options_qa_comment_simplified():
             label="Mark case tasks as seen",
             url=reverse(
                 "notifications:mark-case-comments-read",
-                kwargs={"case_id": simplified_case.id},
-            ),
-        ),
-    ]
-
-
-@pytest.mark.django_db
-def test_options_qa_comment_detailed():
-    """Task options for QA comment in detailed case"""
-    user: User = User.objects.create()
-    detailed_case: DetailedCase = DetailedCase.objects.create(auditor=user)
-    task: Task = Task.objects.create(
-        type=Task.Type.QA_COMMENT,
-        date=date.today(),
-        base_case=detailed_case,
-        user=user,
-    )
-
-    assert task.options() == [
-        Link(
-            label="Go to QA comment",
-            url=reverse(
-                "detailed:edit-qa-comments",
-                kwargs={"pk": detailed_case.id},
-            ),
-        ),
-        Link(
-            label="Mark as seen",
-            url=reverse(
-                "notifications:mark-task-read",
-                kwargs={"pk": task.id},
-            ),
-        ),
-        Link(
-            label="Mark case tasks as seen",
-            url=reverse(
-                "notifications:mark-case-comments-read",
-                kwargs={"case_id": detailed_case.id},
-            ),
-        ),
-    ]
-
-
-@pytest.mark.django_db
-def test_options_qa_comment_mobile():
-    """Task options for QA comment in mobile case"""
-    user: User = User.objects.create()
-    mobile_case: MobileCase = MobileCase.objects.create(auditor=user)
-    task: Task = Task.objects.create(
-        type=Task.Type.QA_COMMENT,
-        date=date.today(),
-        base_case=mobile_case,
-        user=user,
-    )
-
-    assert task.options() == [
-        Link(
-            label="Go to QA comment",
-            url=reverse(
-                "mobile:edit-qa-comments",
-                kwargs={"pk": mobile_case.id},
-            ),
-        ),
-        Link(
-            label="Mark as seen",
-            url=reverse(
-                "notifications:mark-task-read",
-                kwargs={"pk": task.id},
-            ),
-        ),
-        Link(
-            label="Mark case tasks as seen",
-            url=reverse(
-                "notifications:mark-case-comments-read",
-                kwargs={"case_id": mobile_case.id},
+                kwargs={"case_id": case.id},
             ),
         ),
     ]

--- a/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
+++ b/accessibility_monitoring_platform/apps/notifications/tests/test_models.py
@@ -1,6 +1,7 @@
 """Tests - test for notifications models"""
 
 from datetime import date
+from typing import Type
 
 import pytest
 from django.contrib.auth.models import User
@@ -42,7 +43,7 @@ def test_notifications_settings_returns_str():
     ],
 )
 def test_task_options(
-    case_class: DetailedCase | MobileCase | SimplifiedCase,
+    case_class: Type[DetailedCase] | Type[MobileCase] | Type[SimplifiedCase],
     case_test_type: str,
     task_type: Task.Type,
     expected_url: str,
@@ -50,7 +51,9 @@ def test_task_options(
 ):
     """Task options for all case test types and both QA comment and Report approved"""
     user: User = User.objects.create()
-    case: case_class = case_class.objects.create(auditor=user)
+    case: DetailedCase | MobileCase | SimplifiedCase = case_class.objects.create(
+        auditor=user
+    )
     task: Task = Task.objects.create(
         type=task_type,
         date=date.today(),


### PR DESCRIPTION
* Fix mobile QA comments link pointing at detailed URL [#2244](https://trello.com/c/1VIULDPF/2244-mobile-qa-comments-link-pointing-at-detailed)